### PR TITLE
Handle Splunk and Cribl HEC verification responses

### DIFF
--- a/src/logging_agent/config_verification.py
+++ b/src/logging_agent/config_verification.py
@@ -126,8 +126,7 @@ def test_http_connection(url, headers=None, auth=None, compatibility=None):
         if compatibility == 'splunk hec':
             # For Splunk HEC compatibility, perform a POST request with an empty body
             response = requests.post(url, headers=headers, auth=auth, data='', timeout=5)
-            # Valid response is a 400 with a specific error message
-            return response.status_code == 400 and "No data" in response.json().get("text", "")
+            return _is_valid_splunk_hec_response(response)
         else:
             # Default behavior with a GET request
             response = requests.get(url, headers=headers, auth=auth, timeout=5)
@@ -180,8 +179,7 @@ def test_https_connection(url, headers=None, auth=None, verify=True, cert=None, 
         if compatibility == 'splunk hec':
             # For Splunk HEC compatibility, perform a POST request with an empty body
             response = session.post(url, data='', timeout=5)
-            # Valid response is a 400 with a specific error message
-            return response.status_code == 400 and "No data" in response.json().get("text", "")
+            return _is_valid_splunk_hec_response(response)
         else:
             # Default behavior with a GET request
             response = session.get(url, timeout=5)
@@ -189,6 +187,29 @@ def test_https_connection(url, headers=None, auth=None, verify=True, cert=None, 
     except requests.RequestException as e:
         logger.error(f"HTTPS connectivity test failed: {e}")
         return False
+
+
+def _is_valid_splunk_hec_response(response):
+    """Determine if the response represents a successful Splunk/Cribl HEC health check."""
+
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.ok and bool(response.text and response.text.strip())
+
+    text = str(payload.get("text", ""))
+    code = payload.get("code")
+
+    if response.status_code == 400 and "no data" in text.lower():
+        return True
+
+    if response.status_code == 200:
+        if code is not None and str(code) == "0":
+            return True
+        if "success" in text.lower():
+            return True
+
+    return False
 
 def verify_output_connectivity(config):
     """

--- a/tests/logging_agent/test_config_verification.py
+++ b/tests/logging_agent/test_config_verification.py
@@ -1,0 +1,111 @@
+import os
+
+import pytest
+
+os.environ.setdefault("RLA_VERIFY_MODE", "1")
+
+from logging_agent import config_verification
+
+
+class DummyResponse:
+    def __init__(self, status_code, json_data=None, text='', ok=None, json_exc=False):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+        self._json_exc = json_exc
+        self.ok = ok if ok is not None else 200 <= status_code < 300
+
+    def json(self):
+        if self._json_exc:
+            raise ValueError("Invalid JSON")
+        if self._json_data is None:
+            raise ValueError("Invalid JSON")
+        return self._json_data
+
+
+class DummySession:
+    def __init__(self, response):
+        self._response = response
+        self.headers = {}
+        self.auth = None
+        self.cert = None
+        self.verify = True
+
+    def post(self, url, data='', timeout=5):
+        return self._response
+
+    def get(self, url, timeout=5):
+        return self._response
+
+
+def patch_session(monkeypatch, response):
+    monkeypatch.setattr(
+        config_verification.requests,
+        "Session",
+        lambda: DummySession(response),
+    )
+
+
+def test_splunk_hec_http_accepts_no_data(monkeypatch):
+    response = DummyResponse(400, json_data={"text": "No data"})
+    monkeypatch.setattr(
+        config_verification.requests,
+        "post",
+        lambda *args, **kwargs: response,
+    )
+
+    assert config_verification.test_http_connection("http://example", compatibility="splunk hec")
+
+
+def test_splunk_hec_https_accepts_no_data(monkeypatch):
+    response = DummyResponse(400, json_data={"text": "No data"})
+    patch_session(monkeypatch, response)
+
+    assert config_verification.test_https_connection("https://example", compatibility="splunk hec")
+
+
+def test_splunk_hec_accepts_cribl_success(monkeypatch):
+    http_response = DummyResponse(200, json_data={"code": 0})
+    monkeypatch.setattr(
+        config_verification.requests,
+        "post",
+        lambda *args, **kwargs: http_response,
+    )
+
+    https_response = DummyResponse(200, json_data={"text": "Success"})
+    patch_session(monkeypatch, https_response)
+
+    assert config_verification.test_http_connection("http://example", compatibility="splunk hec")
+    assert config_verification.test_https_connection("https://example", compatibility="splunk hec")
+
+
+def test_splunk_hec_accepts_non_json_success(monkeypatch):
+    response = DummyResponse(200, text="OK", json_exc=True)
+    monkeypatch.setattr(
+        config_verification.requests,
+        "post",
+        lambda *args, **kwargs: response,
+    )
+    patch_session(monkeypatch, response)
+
+    assert config_verification.test_http_connection("http://example", compatibility="splunk hec")
+    assert config_verification.test_https_connection("https://example", compatibility="splunk hec")
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        DummyResponse(500, json_data={"text": "error"}),
+        DummyResponse(200, json_data={"text": "Unexpected"}),
+    ],
+)
+def test_splunk_hec_rejects_unexpected_responses(monkeypatch, response):
+    monkeypatch.setattr(
+        config_verification.requests,
+        "post",
+        lambda *args, **kwargs: response,
+    )
+    patch_session(monkeypatch, response)
+
+    assert not config_verification.test_http_connection("http://example", compatibility="splunk hec")
+    assert not config_verification.test_https_connection("https://example", compatibility="splunk hec")


### PR DESCRIPTION
## Summary
- allow Splunk HEC connectivity checks to accept Cribl-style 200/Success responses and tolerate non-JSON bodies
- share the Splunk/Cribl response validation logic between HTTP and HTTPS checks
- add unit tests for Splunk "No data", Cribl success, non-JSON success, and unexpected responses

## Testing
- RLA_VERIFY_MODE=1 PYTHONPATH=src pytest tests/logging_agent/test_config_verification.py

------
https://chatgpt.com/codex/tasks/task_b_68fe770eedbc832087742f70c9c44311