### PR TITLE
Add configuration handling for file and SFTP agents

### DIFF
--- a/config/rla.yaml
+++ b/config/rla.yaml
@@ -33,7 +33,7 @@ aws_credentials:
 # Configuration of individual agents for log collection. Each agent can be configured for different sources and products.
 agents:
   - name: "cloud"  # Unique name of the agent.
-    type: "sqs"  # Type of log source. Current options: "sqs".
+    type: "sqs"  # Type of log source. Options: "sqs", "file", "sftp".
     num_worker_threads: 5  # Number of worker threads for processing messages.
     product: "cloud_waap"  # The product type associated with this agent. Current options: "cloud_waap".
     sqs_settings:
@@ -46,6 +46,42 @@ agents:
       DDoS: true  # Enable or disable ingestion of 'DDoS' logs.
       WebDDoS: true  # Enable or disable ingestion of 'WebDDoS' logs.
       CSP: true  # Enable or disable ingestion of 'CSP' logs.
+
+  # Example: Local file system agent for processing dropped log files
+  # - name: "local-files"
+  #   type: "file"
+  #   num_worker_threads: 2
+  #   product: "cloud_waap"
+  #   file_settings:
+  #     root_path: "/var/spool/rla/incoming"  # Directory polled for new files
+  #     polling_interval_seconds: 10           # How frequently to scan the directory
+  #     completion_strategy:
+  #       mode: "archive"                     # Options: "archive", "delete"
+  #       archive_directory: "/var/spool/rla/archive"
+  #   logs:
+  #     Access: true
+  #     WAF: true
+
+  # Example: Embedded SFTP drop-zone for partners
+  # - name: "sftp-drop"
+  #   type: "sftp"
+  #   num_worker_threads: 2
+  #   product: "cloud_waap"
+  #   sftp_settings:
+  #     listen:
+  #       host: "0.0.0.0"
+  #       port: 2222
+  #     host_keys:
+  #       - "/etc/rla/ssh_host_ed25519_key"
+  #     drop_directory: "/var/spool/rla/sftp-drop"   # Ensure owned by the RLA user and not world-writable
+  #     credential_policy:
+  #       mode: "static"                              # Options: "static", "public_key"
+  #       users:
+  #         - username: "partner"
+  #           password: "change-me"                  # Rotate frequently; prefer secrets management.
+  #           home_directory: "/var/spool/rla/sftp-drop/partner"
+  #   logs:
+  #     Access: true
 
 # Output Configuration
 # --------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,13 +79,31 @@ Configure AWS credentials to allow RLA to interact with AWS services such as SQS
 Define settings for each log collection agent.
 
 - **name**: Assign a unique name for each agent.
-- **type**: Define the type of log source. Currently, "sqs" is supported.
+- **type**: Define the type of log source. Supported values are `sqs`, `file`, and `sftp`.
 - **num_worker_threads**: Set the number of worker threads for processing messages.
-- **product**: Specify the product type associated with this agent. Currently supports 'cloud_waap'.
+- **product**: Specify the product type associated with this agent. Currently supports `cloud_waap`.
 - **sqs_settings**:
   - **queue_name**: The name of the SQS queue to poll for messages.
   - **delete_on_failure**: Determine whether to delete messages from the queue if processing fails (true/false).
+- **file_settings**:
+  - **root_path**: Directory that RLA will poll for new log files. The directory must already exist and be writable by the agent user.
+  - **polling_interval_seconds**: Frequency (in seconds) for scanning the directory for new files.
+  - **completion_strategy**: Determines how processed files are handled. Supported modes are `delete` and `archive`. When `archive` is selected, specify **archive_directory** where processed files will be moved.
+- **sftp_settings**:
+  - **listen**: Host and port where the embedded SFTP service listens for client connections.
+  - **host_keys**: List of private host key files (e.g., Ed25519 or RSA). All files must exist and remain readable by RLA.
+  - **drop_directory**: Root directory for uploaded files; ensure it is owned by the RLA service account and not world-writable.
+  - **credential_policy**: Controls how clients authenticate. Use `static` for username/password credentials or `public_key` for SSH public key authentication. Each user entry includes a **username** and either a **password** (`static`) or **authorized_keys** list (`public_key`). Optional **home_directory** overrides must point to writable directories.
 - **logs**: Enable or disable specific log types for processing, such as `Access`, `WAF`, `Bot`, `DDoS`, `WebDDoS`, and `CSP`.
+
+### Secure SFTP Guidance
+
+When exposing the built-in SFTP drop-zone, harden the deployment:
+
+- Generate dedicated host keys and store them with restrictive permissions owned by the RLA account.
+- Prefer the `public_key` credential policy with per-partner keys; if passwords are required, rotate them regularly and deliver through a secrets manager.
+- Place `drop_directory` on a filesystem with adequate quotas and ensure it is not world-writable. Create per-tenant subdirectories with appropriate ownership.
+- Use network controls (firewalls, security groups) to restrict inbound SFTP access to approved partners.
 
 ## Output Configuration
 
@@ -185,6 +203,40 @@ agents:
       DDoS: true
       WebDDoS: true
       CSP: false
+
+  - name: "local-files"
+    type: "file"
+    num_worker_threads: 2
+    product: "cloud_waap"
+    file_settings:
+      root_path: '/var/spool/rla/incoming'
+      polling_interval_seconds: 10
+      completion_strategy:
+        mode: 'archive'
+        archive_directory: '/var/spool/rla/archive'
+    logs:
+      Access: true
+
+  - name: "sftp-drop"
+    type: "sftp"
+    num_worker_threads: 2
+    product: "cloud_waap"
+    sftp_settings:
+      listen:
+        host: '0.0.0.0'
+        port: 2222
+      host_keys:
+        - '/etc/rla/ssh_host_ed25519_key'
+      drop_directory: '/var/spool/rla/sftp-drop'
+      credential_policy:
+        mode: 'public_key'
+        users:
+          - username: 'partner'
+            authorized_keys:
+              - '/etc/rla/partners/partner.pub'
+            home_directory: '/var/spool/rla/sftp-drop/partner'
+    logs:
+      Access: true
 
 output:
   output_format: 'json'  # Supports 'json', 'cef', 'leef'

--- a/src/logging_agent/app_info.py
+++ b/src/logging_agent/app_info.py
@@ -9,7 +9,20 @@ supported_features = {
         },
         "supported_conversions": ['cef', 'leef', "json"],
         "supported_log_types": ['CSP', "Access", "WAF", "Bot", "DDoS", "WebDDoS"],
-        "supported_input_type": ['sqs'],
+        "supported_input_type": ['sqs', 'file', 'sftp'],
+        "input_type_requirements": {
+            "file": {
+                "completion_modes": ["delete", "archive"],
+                "polling_interval_seconds": {
+                    "min": 1,
+                    "max": 3600
+                }
+            },
+            "sftp": {
+                "credential_modes": ["static", "public_key"],
+                "default_port": 2222
+            }
+        },
         "compatibility_mode_conversion_function": ['splunk hec', 'ecs'],
         "compatibility_mode": ['splunk hec', 'ecs'],
         "compatibility_mode_requirements": {

--- a/src/logging_agent/config_reader.py
+++ b/src/logging_agent/config_reader.py
@@ -162,7 +162,10 @@ class Config:
                 self.config['output']['batch'] = False
 
             # Process agents
-            self.config['agents'] = {agent['name']: agent for agent in self.config.get('agents', [])}
+            normalized_agents = []
+            for agent in self.config.get('agents', []):
+                normalized_agents.append(self._normalize_agent(agent))
+            self.config['agents'] = {agent['name']: agent for agent in normalized_agents}
 
         except yaml.YAMLError as exc:
             raise Exception(f"Error reading YAML: {exc}")
@@ -260,6 +263,119 @@ class Config:
                 target_format_dict[key] = default_value
             elif isinstance(existing_value, dict) and isinstance(default_value, dict):
                 self._apply_format_defaults(existing_value, default_value)
+
+    def _normalize_agent(self, agent):
+        agent_type = (agent.get('type') or '').lower()
+        product = agent.get('product')
+
+        if agent_type == 'file':
+            file_settings = agent.get('file_settings', {}) or {}
+            root_path = file_settings.get('root_path')
+            if root_path:
+                file_settings['root_path'] = str(self.normalize_path(root_path))
+
+            polling_interval = file_settings.get('polling_interval_seconds')
+            if polling_interval is not None:
+                try:
+                    file_settings['polling_interval_seconds'] = int(polling_interval)
+                except (TypeError, ValueError):
+                    file_settings['polling_interval_seconds'] = polling_interval
+
+            completion_strategy = file_settings.get('completion_strategy')
+            if isinstance(completion_strategy, str):
+                completion_strategy = {'mode': completion_strategy}
+            elif completion_strategy is None:
+                completion_strategy = {}
+            else:
+                completion_strategy = dict(completion_strategy)
+
+            archive_directory = completion_strategy.get('archive_directory')
+            if archive_directory:
+                completion_strategy['archive_directory'] = str(self.normalize_path(archive_directory))
+
+            file_settings['completion_strategy'] = completion_strategy
+            agent['file_settings'] = file_settings
+
+        elif agent_type == 'sftp':
+            sftp_settings = agent.get('sftp_settings', {}) or {}
+
+            listen = sftp_settings.pop('listen_address', None) or sftp_settings.get('listen', {})
+            listen_host = '0.0.0.0'
+            listen_port = None
+
+            if isinstance(listen, str):
+                host_part, _, port_part = listen.partition(':')
+                if host_part:
+                    listen_host = host_part
+                if port_part:
+                    try:
+                        listen_port = int(port_part)
+                    except ValueError:
+                        listen_port = None
+            elif isinstance(listen, dict):
+                listen_host = listen.get('host', listen_host)
+                port_value = listen.get('port')
+                try:
+                    listen_port = int(port_value) if port_value is not None else None
+                except (TypeError, ValueError):
+                    listen_port = None
+
+            requirements = supported_features.get(product or 'cloud_waap', {}).get('input_type_requirements', {})
+            default_port = requirements.get('sftp', {}).get('default_port', 2222)
+            if listen_port is None:
+                listen_port = default_port
+
+            sftp_settings['listen'] = {'host': listen_host, 'port': listen_port}
+
+            host_keys = sftp_settings.get('host_keys', [])
+            if isinstance(host_keys, (str, Path)):
+                host_keys = [host_keys]
+            normalized_host_keys = []
+            for key_path in host_keys:
+                if key_path:
+                    normalized_host_keys.append(str(self.normalize_path(str(key_path))))
+            sftp_settings['host_keys'] = normalized_host_keys
+
+            drop_directory = sftp_settings.get('drop_directory')
+            if drop_directory:
+                sftp_settings['drop_directory'] = str(self.normalize_path(drop_directory))
+
+            credential_policy = sftp_settings.get('credential_policy')
+            if isinstance(credential_policy, str):
+                credential_policy = {'mode': credential_policy}
+            elif credential_policy is None:
+                credential_policy = {}
+            else:
+                credential_policy = dict(credential_policy)
+
+            users = credential_policy.get('users', [])
+            if isinstance(users, dict):
+                users = [users]
+
+            normalized_users = []
+            for user in users:
+                normalized_user = dict(user)
+                home_dir = normalized_user.get('home_directory')
+                if home_dir:
+                    normalized_user['home_directory'] = str(self.normalize_path(home_dir))
+
+                authorized_keys = normalized_user.get('authorized_keys')
+                if isinstance(authorized_keys, (str, Path)):
+                    authorized_keys = [authorized_keys]
+                if authorized_keys:
+                    normalized_user['authorized_keys'] = [
+                        str(self.normalize_path(str(key_path))) for key_path in authorized_keys if key_path
+                    ]
+
+                normalized_users.append(normalized_user)
+
+            if normalized_users:
+                credential_policy['users'] = normalized_users
+
+            sftp_settings['credential_policy'] = credential_policy
+            agent['sftp_settings'] = sftp_settings
+
+        return agent
     def get_all_products(self):
         """
         Returns a list of all unique products assigned to agents.

--- a/src/logging_agent/config_verification.py
+++ b/src/logging_agent/config_verification.py
@@ -11,6 +11,17 @@ import certifi
 logger = get_logger('config_verification')
 
 
+def _directory_is_writable(path):
+    return os.path.isdir(path) and os.access(path, os.W_OK)
+
+
+def _validate_authorized_keys(key_paths):
+    for key_path in key_paths:
+        if not os.path.isfile(key_path):
+            logger.error(f"Authorized key file not found: {key_path}")
+            return False
+    return True
+
 
 def test_tcp_connection(host, port, timeout=5, compatibility=None):
     """
@@ -374,7 +385,8 @@ def verify_agent_config(agent_config):
         logger.error(f"Unsupported product: {product} in agent {agent_config['name']}")
         return False
 
-    if agent_config['type'] not in supported_features[product]['supported_input_type']:
+    agent_type = (agent_config.get('type') or '').lower()
+    if agent_type not in supported_features[product]['supported_input_type']:
         logger.error(f"Unsupported input type: {agent_config['type']} for product: {product} in agent {agent_config['name']}")
         return False
 
@@ -411,6 +423,132 @@ def verify_agent_config(agent_config):
                 f" and output format must be one of {requirements.get('output_format', [])}."
             )
             return False
+
+    input_requirements = supported_features[product].get('input_type_requirements', {})
+
+    if agent_type == 'file':
+        file_settings = agent_config.get('file_settings')
+        if not file_settings:
+            logger.error(f"File agent {agent_config['name']} must define file_settings")
+            return False
+
+        root_path = file_settings.get('root_path')
+        if not root_path or not os.path.isdir(root_path):
+            logger.error(f"File agent {agent_config['name']} root_path is invalid: {root_path}")
+            return False
+        if not _directory_is_writable(root_path):
+            logger.error(f"File agent {agent_config['name']} root_path is not writable: {root_path}")
+            return False
+
+        polling_interval = file_settings.get('polling_interval_seconds')
+        if polling_interval is None:
+            logger.error(f"File agent {agent_config['name']} must define polling_interval_seconds")
+            return False
+        try:
+            polling_interval = int(polling_interval)
+        except (TypeError, ValueError):
+            logger.error(f"File agent {agent_config['name']} polling_interval_seconds must be an integer")
+            return False
+
+        polling_constraints = input_requirements.get('file', {}).get('polling_interval_seconds', {})
+        min_poll = polling_constraints.get('min')
+        max_poll = polling_constraints.get('max')
+        if min_poll is not None and polling_interval < min_poll:
+            logger.error(f"File agent {agent_config['name']} polling interval {polling_interval} below minimum {min_poll}")
+            return False
+        if max_poll is not None and polling_interval > max_poll:
+            logger.error(f"File agent {agent_config['name']} polling interval {polling_interval} exceeds maximum {max_poll}")
+            return False
+
+        completion_strategy = file_settings.get('completion_strategy', {})
+        if isinstance(completion_strategy, str):
+            completion_strategy = {'mode': completion_strategy}
+
+        mode = completion_strategy.get('mode')
+        allowed_modes = input_requirements.get('file', {}).get('completion_modes', [])
+        if mode not in allowed_modes:
+            logger.error(f"File agent {agent_config['name']} completion mode '{mode}' is not supported")
+            return False
+
+        if mode == 'archive':
+            archive_directory = completion_strategy.get('archive_directory')
+            if not archive_directory or not os.path.isdir(archive_directory):
+                logger.error(f"File agent {agent_config['name']} archive_directory is invalid: {archive_directory}")
+                return False
+            if not _directory_is_writable(archive_directory):
+                logger.error(f"File agent {agent_config['name']} archive_directory is not writable: {archive_directory}")
+                return False
+
+    if agent_type == 'sftp':
+        sftp_settings = agent_config.get('sftp_settings')
+        if not sftp_settings:
+            logger.error(f"SFTP agent {agent_config['name']} must define sftp_settings")
+            return False
+
+        listen = sftp_settings.get('listen', {})
+        port = listen.get('port')
+        try:
+            port = int(port)
+        except (TypeError, ValueError):
+            logger.error(f"SFTP agent {agent_config['name']} listen port is invalid: {port}")
+            return False
+        if not (0 < port < 65536):
+            logger.error(f"SFTP agent {agent_config['name']} listen port out of range: {port}")
+            return False
+
+        drop_directory = sftp_settings.get('drop_directory')
+        if not drop_directory or not os.path.isdir(drop_directory):
+            logger.error(f"SFTP agent {agent_config['name']} drop_directory is invalid: {drop_directory}")
+            return False
+        if not _directory_is_writable(drop_directory):
+            logger.error(f"SFTP agent {agent_config['name']} drop_directory is not writable: {drop_directory}")
+            return False
+
+        host_keys = sftp_settings.get('host_keys', [])
+        if not host_keys:
+            logger.error(f"SFTP agent {agent_config['name']} must define at least one host key")
+            return False
+        for host_key in host_keys:
+            if not os.path.isfile(host_key):
+                logger.error(f"SFTP agent {agent_config['name']} host key not found: {host_key}")
+                return False
+
+        credential_policy = sftp_settings.get('credential_policy') or {}
+        mode = credential_policy.get('mode')
+        allowed_modes = input_requirements.get('sftp', {}).get('credential_modes', [])
+        if mode not in allowed_modes:
+            logger.error(f"SFTP agent {agent_config['name']} credential mode '{mode}' is not supported")
+            return False
+
+        users = credential_policy.get('users', [])
+        if not users:
+            logger.error(f"SFTP agent {agent_config['name']} credential policy requires at least one user definition")
+            return False
+
+        for user in users:
+            username = user.get('username')
+            if not username:
+                logger.error(f"SFTP agent {agent_config['name']} has a user without a username")
+                return False
+
+            home_directory = user.get('home_directory')
+            if home_directory and (not os.path.isdir(home_directory) or not _directory_is_writable(home_directory)):
+                logger.error(
+                    f"SFTP agent {agent_config['name']} home_directory for user {username} is invalid or not writable"
+                )
+                return False
+
+            if mode == 'static':
+                if not user.get('password'):
+                    logger.error(f"SFTP agent {agent_config['name']} static user {username} missing password")
+                    return False
+            elif mode == 'public_key':
+                authorized_keys = user.get('authorized_keys', [])
+                if not authorized_keys:
+                    logger.error(f"SFTP agent {agent_config['name']} public_key user {username} missing authorized_keys")
+                    return False
+                if not _validate_authorized_keys(authorized_keys):
+                    return False
 
     return True
 

--- a/tests/logging_agent/test_config_verification.py
+++ b/tests/logging_agent/test_config_verification.py
@@ -46,6 +46,130 @@ def patch_session(monkeypatch, response):
     )
 
 
+def _base_output():
+    return {
+        'type': 'http',
+        'output_format': 'json',
+        'compatibility_mode': None,
+    }
+
+
+def test_verify_agent_config_accepts_file_agent(tmp_path):
+    root_path = tmp_path / "incoming"
+    archive_path = tmp_path / "archive"
+    root_path.mkdir()
+    archive_path.mkdir()
+
+    agent_config = {
+        'name': 'file-agent',
+        'type': 'file',
+        'product': 'cloud_waap',
+        'logs': {'Access': True},
+        'output': _base_output(),
+        'file_settings': {
+            'root_path': str(root_path),
+            'polling_interval_seconds': 30,
+            'completion_strategy': {
+                'mode': 'archive',
+                'archive_directory': str(archive_path),
+            }
+        }
+    }
+
+    assert config_verification.verify_agent_config(agent_config)
+
+
+def test_verify_agent_config_rejects_file_agent_with_missing_archive(tmp_path):
+    root_path = tmp_path / "incoming"
+    root_path.mkdir()
+
+    agent_config = {
+        'name': 'file-agent-invalid',
+        'type': 'file',
+        'product': 'cloud_waap',
+        'logs': {'Access': True},
+        'output': _base_output(),
+        'file_settings': {
+            'root_path': str(root_path),
+            'polling_interval_seconds': 30,
+            'completion_strategy': {
+                'mode': 'archive',
+                'archive_directory': str(root_path / "archive"),
+            }
+        }
+    }
+
+    assert not config_verification.verify_agent_config(agent_config)
+
+
+def test_verify_agent_config_accepts_sftp_agent_public_key(tmp_path):
+    drop_directory = tmp_path / "drop"
+    host_key = tmp_path / "ssh_host_ed25519_key"
+    authorized_key = tmp_path / "partner.pub"
+    user_home = drop_directory / "partner"
+
+    drop_directory.mkdir()
+    user_home.mkdir()
+    host_key.write_text("dummy")
+    authorized_key.write_text("ssh-ed25519 AAAA test")
+
+    agent_config = {
+        'name': 'sftp-agent',
+        'type': 'sftp',
+        'product': 'cloud_waap',
+        'logs': {'Access': True},
+        'output': _base_output(),
+        'sftp_settings': {
+            'listen': {'host': '0.0.0.0', 'port': 2222},
+            'host_keys': [str(host_key)],
+            'drop_directory': str(drop_directory),
+            'credential_policy': {
+                'mode': 'public_key',
+                'users': [
+                    {
+                        'username': 'partner',
+                        'authorized_keys': [str(authorized_key)],
+                        'home_directory': str(user_home),
+                    }
+                ],
+            },
+        }
+    }
+
+    assert config_verification.verify_agent_config(agent_config)
+
+
+def test_verify_agent_config_rejects_sftp_agent_missing_password(tmp_path):
+    drop_directory = tmp_path / "drop"
+    host_key = tmp_path / "ssh_host_ed25519_key"
+
+    drop_directory.mkdir()
+    host_key.write_text("dummy")
+
+    agent_config = {
+        'name': 'sftp-agent-invalid',
+        'type': 'sftp',
+        'product': 'cloud_waap',
+        'logs': {'Access': True},
+        'output': _base_output(),
+        'sftp_settings': {
+            'listen': {'host': '0.0.0.0', 'port': 2222},
+            'host_keys': [str(host_key)],
+            'drop_directory': str(drop_directory),
+            'credential_policy': {
+                'mode': 'static',
+                'users': [
+                    {
+                        'username': 'partner',
+                    }
+                ],
+            },
+        }
+    }
+
+    assert not config_verification.verify_agent_config(agent_config)
+
+
 def test_splunk_hec_http_accepts_no_data(monkeypatch):
     response = DummyResponse(400, json_data={"text": "No data"})
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add Cloud WAAP metadata for file and SFTP ingestion and normalize agent-specific settings when loading configuration
- validate file and SFTP agent definitions, including filesystem and credential prerequisites
- document the new agent types and extend configuration tests for valid and invalid scenarios

## Testing
- PYTHONPATH=src pytest tests/logging_agent/test_config_verification.py

------
https://chatgpt.com/codex/tasks/task_b_690084fbe6c48320bc23ac134eba8001