### PR TITLE
Add local file and SFTP loading with cleanup controls

### DIFF
--- a/src/logging_agent/data_loader.py
+++ b/src/logging_agent/data_loader.py
@@ -12,13 +12,20 @@ class DataLoader:
         self.logger = get_logger('data_loader')  # Initialize logger as an instance attribute
 
     def load_data(self, input_type, input_info):
-        if input_type == "sqs":
-            return self.load_from_s3(input_info)
-        else:
+        loaders = {
+            "sqs": self.load_from_s3,
+            "file": self.load_from_file_system,
+            "sftp": self.load_from_file_system,
+        }
+
+        loader = loaders.get(input_type)
+        if not loader:
             self.logger.error(f"Unsupported input type: {input_type}")
             return {"data": None, "metadata": {}}
 
-    def load_from_s3(self, input_info):
+        return loader(input_info, input_type)
+
+    def load_from_s3(self, input_info, input_type="sqs"):
         """
         Loads data from S3. Checks if the file already exists, handles partial files,
         and downloads the file if required.
@@ -34,6 +41,12 @@ class DataLoader:
         expected_size = input_info.get('expected_size', '')
         output_directory = self.config.get('output_directory', '/tmp')
         download_path = os.path.join(output_directory, os.path.basename(key))
+        metadata = {
+            "file_path": download_path,
+            "key": key,
+            "relative_key": key,
+            "cleanup": True,
+        }
 
         # Check if file already exists and decide whether to download
         download_required = True
@@ -55,27 +68,78 @@ class DataLoader:
             downloader = S3Downloader(s3_config)
             if not downloader.download(bucket, key, download_path):
                 self.logger.error(f"Failed to download {key} from bucket {bucket}")
-                return None
+                return {"data": None, "metadata": metadata}
 
-        # Determine the file type and process accordingly
-        file_extension = os.path.splitext(download_path)[1]
         try:
-            if file_extension == '.gz':
-                # Decompress and load JSON data
-                with gzip.open(download_path, 'rt') as f:
-                    data = json.load(f)
-            elif file_extension == '.json':
-                # Load JSON data
-                with open(download_path, 'r') as f:
-                    data = json.load(f)
-            elif file_extension == '.ndjson':
-                # Load NDJSON data
-                with open(download_path, 'r') as f:
-                    data = [json.loads(line) for line in f]
-            else:
-                self.logger.error(f"Unsupported file format: {file_extension}")
-                return {"data": None, "metadata": {}}
-            return {"data": data, "metadata": {"file_path": download_path, "key": key}}
+            data = self._load_local_file(download_path)
+            if data is None:
+                return {"data": None, "metadata": metadata}
+            return {"data": data, "metadata": metadata}
         except Exception as e:
             self.logger.error(f"Error processing file: {download_path}: {e}")
-            return {"data": None, "metadata": {"file_path": download_path, "key": key}}
+            return {"data": None, "metadata": metadata}
+
+    def load_from_file_system(self, input_info, input_type):
+        root_path = None
+        if input_type == "file":
+            root_path = self.config.get('file_settings', {}).get('root_path')
+        elif input_type == "sftp":
+            root_path = self.config.get('sftp_settings', {}).get('drop_directory')
+
+        provided_path = input_info.get('file_path') or input_info.get('path')
+        if not provided_path:
+            self.logger.error(f"No file path provided for input type: {input_type}")
+            return {"data": None, "metadata": {}}
+
+        absolute_path = provided_path
+        if not os.path.isabs(absolute_path):
+            if root_path:
+                absolute_path = os.path.join(root_path, absolute_path)
+            absolute_path = os.path.abspath(absolute_path)
+        else:
+            absolute_path = os.path.abspath(absolute_path)
+
+        if not os.path.exists(absolute_path):
+            self.logger.error(f"File does not exist: {absolute_path}")
+            return {"data": None, "metadata": {}}
+
+        relative_key = self._compute_relative_key(absolute_path, root_path)
+        metadata = {
+            "file_path": absolute_path,
+            "key": relative_key,
+            "relative_key": relative_key,
+            "cleanup": False,
+        }
+
+        try:
+            data = self._load_local_file(absolute_path)
+            if data is None:
+                return {"data": None, "metadata": metadata}
+            return {"data": data, "metadata": metadata}
+        except Exception as e:
+            self.logger.error(f"Error processing file: {absolute_path}: {e}")
+            return {"data": None, "metadata": metadata}
+
+    def _load_local_file(self, path):
+        file_extension = os.path.splitext(path)[1].lower()
+        if file_extension == '.gz':
+            with gzip.open(path, 'rt') as f:
+                return json.load(f)
+        if file_extension == '.json':
+            with open(path, 'r') as f:
+                return json.load(f)
+        if file_extension == '.ndjson':
+            with open(path, 'r') as f:
+                return [json.loads(line) for line in f]
+
+        self.logger.error(f"Unsupported file format: {file_extension}")
+        return None
+
+    @staticmethod
+    def _compute_relative_key(absolute_path, root_path):
+        if root_path:
+            try:
+                return os.path.relpath(absolute_path, root_path)
+            except ValueError:
+                pass
+        return os.path.basename(absolute_path)

--- a/src/logging_agent/data_processor.py
+++ b/src/logging_agent/data_processor.py
@@ -42,13 +42,16 @@ class DataProcessor:
         load_end_time = datetime.datetime.now()
         self.logger.info(f"Loading completed. Time taken: {load_end_time - load_start_time}. File size: {file_size} bytes")
 
-        data = loaded_data.get('data', None)
-        metadata = loaded_data.get('metadata', {})
+        data = None
+        metadata = {}
+        if loaded_data:
+            data = loaded_data.get('data')
+            metadata = loaded_data.get('metadata', {})
         if data is None:
             self.logger.error(f"Failed to load data for input type: {input_type}")
             return False
 
-        log_type = self.identify_product_log_type(input_fields, input_type, product)
+        log_type = self.identify_product_log_type(input_fields, metadata, input_type, product)
         # Check if the log type is supported for the product
         if log_type not in supported_features[product]["supported_log_types"]:
             self.logger.info(f"Skipping unsupported log type {log_type} for product {product}.")
@@ -59,7 +62,7 @@ class DataProcessor:
             self.logger.info(f"Skipping log type {log_type} as per configuration.")
             return True  # Successfully handled by skipping
 
-        data_fields = self.gather_data_fields(input_fields, input_type, log_type, product)
+        data_fields = self.gather_data_fields(input_fields, metadata, input_type, log_type, product)
         transform_start_time = datetime.datetime.now()
         transformed_data = self.transform_data(data, data_fields)
         transform_end_time = datetime.datetime.now()
@@ -77,7 +80,8 @@ class DataProcessor:
 
         # Cleanup
         file_path = metadata.get('file_path')
-        if file_path:
+        cleanup_flag = metadata.get('cleanup')
+        if success and cleanup_flag and file_path:
             Utility.cleanup(file_path)
 
         # Cleanup and final logging
@@ -87,7 +91,7 @@ class DataProcessor:
         #self.logger.info(f"Task completed. Time taken: {end_time - start_time}")
         return success
 
-    def identify_product_log_type(self, log_info, input_type, product):
+    def identify_product_log_type(self, log_info, metadata, input_type, product):
         """
         Identifies the log type based on product and input type.
 
@@ -100,12 +104,12 @@ class DataProcessor:
             str: Identified log type.
         """
         log_type = ""
-        if input_type == "sqs" and product == "cloud_waap":
-            key = log_info.get('key', '')
+        if input_type in {"sqs", "file", "sftp"} and product == "cloud_waap":
+            key = metadata.get('relative_key') or metadata.get('key') or log_info.get('key', '')
             log_type = CloudWAAPProcessor.identify_log_type(key)
         return log_type
 
-    def gather_data_fields(self, input_fields, input_type, log_type, product):
+    def gather_data_fields(self, input_fields, metadata, input_type, log_type, product):
         """
         Gathers additional data fields required for transformation.
 
@@ -119,15 +123,15 @@ class DataProcessor:
             dict: Data fields collected for transformation.
         """
         data_fields = {}
-        if input_type == "sqs" and product == "cloud_waap":
-            key = input_fields.get('key')
-            metadata = CloudWAAPProcessor.extract_metadata(key, product, log_type)
+        if input_type in {"sqs", "file", "sftp"} and product == "cloud_waap":
+            key = metadata.get('relative_key') or metadata.get('key') or input_fields.get('key')
+            waap_metadata = CloudWAAPProcessor.extract_metadata(key, product, log_type)
             data_fields = {
                 'key': key,
                 'input_type': input_type,
                 'log_type': log_type,
                 'product': product,
-                'metadata': metadata
+                'metadata': waap_metadata
             }
         return data_fields
 

--- a/tests/logging_agent/conftest.py
+++ b/tests/logging_agent/conftest.py
@@ -44,7 +44,7 @@ def input_info():
     "key": "CWAAP-Logs-unprocessed/Access-Logs/805c88ac-aaf9-471a-9030-391c0393990d/rdwr_log_DEMO_New CWAF Automated Demo_20240131H070000_20240131H070500_79244803-9682-4d0f-924d-567268708991.json"
 }
 @pytest.fixture
-def mock_s3_downloader(mocker):
+def mock_s3_downloader():
     with patch('logging_agent.data_loader.S3Downloader') as MockDownloader:
         mock_instance = MockDownloader.return_value
         mock_instance.download.return_value = True  # Simulate successful download
@@ -91,21 +91,27 @@ def mock_dependencies(monkeypatch):
     mock_data_loader = MagicMock(spec=DataLoader)
     mock_transformer = MagicMock(spec=Transformer)
     mock_sender_send_data = MagicMock(return_value=True)  # This mock is for the send_data method specifically
+    mock_cleanup = MagicMock()
 
     # Correctly replace the instances where these would be instantiated
     monkeypatch.setattr("logging_agent.data_processor.DataLoader", lambda config: mock_data_loader)
     monkeypatch.setattr("logging_agent.data_processor.Transformer", lambda config: mock_transformer)
     monkeypatch.setattr("logging_agent.sender.Sender.send_data", mock_sender_send_data)  # Correctly mock the static method
+    monkeypatch.setattr("logging_agent.data_processor.Utility.cleanup", mock_cleanup)
 
 
     # Setup mock return values
-    mock_data_loader.load_data.return_value = {'data': [{'sample': 'data'}], 'metadata': {}}
+    mock_data_loader.load_data.return_value = {
+        'data': [{'sample': 'data'}],
+        'metadata': {'cleanup': True, 'file_path': '/tmp/mock-file', 'relative_key': 'mock-key'}
+    }
     mock_transformer.transform_content.return_value = [{'sample': 'data'}]
 
     return {
         'data_loader': mock_data_loader,
         'transformer': mock_transformer,
-        'sender_send_data': mock_sender_send_data
+        'sender_send_data': mock_sender_send_data,
+        'utility_cleanup': mock_cleanup
     }
 
 @pytest.fixture

--- a/tests/logging_agent/test_data_loader.py
+++ b/tests/logging_agent/test_data_loader.py
@@ -1,11 +1,11 @@
-import pytest
-import json
-from logging_agent.data_loader import DataLoader
-from io import StringIO
-from logging_agent.downloader import S3Downloader
+import os
 import json
 import gzip
-from unittest.mock import MagicMock
+
+import pytest
+
+from logging_agent.data_loader import DataLoader
+
 
 def test_load_data_unsupported_type(config):
     dataloader = DataLoader(config)
@@ -13,85 +13,122 @@ def test_load_data_unsupported_type(config):
     assert result == {"data": None, "metadata": {}}
 
 
-def test_load_from_s3_file_exists(mocker, mock_s3_downloader, config, input_info):
-    # Mock data to be returned by the json file
+def test_load_from_s3_file_exists(monkeypatch, mock_s3_downloader, config, input_info):
     mock_data = {"test": "data"}
 
-    # Mock open to return a StringIO object, simulating reading from a file
-    mocker.patch("builtins.open", mocker.mock_open(read_data=json.dumps(mock_data)))
-
-    # Mock os.path.exists to simulate the file existence
-    mocker.patch('os.path.exists', return_value=True)
-
-    # Mock os.path.getsize to simulate the file size check
-    mocker.patch('os.path.getsize', return_value=100)
-
-    # Mock os.makedirs in case the directory creation is triggered
-    mocker.patch('os.makedirs', MagicMock())
+    monkeypatch.setattr('os.path.exists', lambda path: True)
+    monkeypatch.setattr('os.path.getsize', lambda path: 100)
+    monkeypatch.setattr('os.makedirs', lambda *args, **kwargs: None)
+    monkeypatch.setattr('glob.glob', lambda pattern: [])
+    monkeypatch.setattr(DataLoader, '_load_local_file', lambda self, path: mock_data)
 
     dataloader = DataLoader(config)
     result = dataloader.load_data("sqs", input_info)
 
-    # Validate the result
     assert result['data'] == mock_data
-    assert 'file_path' in result['metadata']
+    metadata = result['metadata']
+    assert metadata['key'] == input_info['key']
+    assert metadata['relative_key'] == input_info['key']
+    assert metadata['cleanup'] is True
 
-def test_load_from_s3_download_required(mocker, mock_s3_downloader, config, input_info):
-    # Simulate file not existing locally
-    mocker.patch('os.path.exists', side_effect=lambda path: False)
-    mocker.patch('os.makedirs', MagicMock())  # Mock directory creation
 
-    # Mock successful file download
+def test_load_from_s3_download_required(monkeypatch, mock_s3_downloader, config, input_info):
+    monkeypatch.setattr('os.path.exists', lambda path: False)
+    monkeypatch.setattr('os.makedirs', lambda *args, **kwargs: None)
+
     mock_s3_downloader.download.return_value = True
-
-    # Mock file reading with sample data
     sample_data = {"sample": "data"}
-    mocker.patch('builtins.open', mocker.mock_open(read_data=json.dumps(sample_data)))
+    monkeypatch.setattr(DataLoader, '_load_local_file', lambda self, path: sample_data)
 
     dataloader = DataLoader(config)
     result = dataloader.load_data("sqs", input_info)
 
     assert result['data'] == sample_data
-    assert 'file_path' in result['metadata']
+    metadata = result['metadata']
+    assert metadata['cleanup'] is True
+    assert metadata['key'] == input_info['key']
 
-def test_load_from_s3_download_failure(mocker, mock_s3_downloader, config, input_info):
-    # Simulate the file not existing locally
-    mocker.patch('os.path.exists', side_effect=lambda path: False)
-    mocker.patch('os.makedirs', MagicMock())  # Mock directory creation if it doesn't exist
 
-    # Simulate the download attempt failing
+def test_load_from_s3_download_failure(monkeypatch, mock_s3_downloader, config, input_info):
+    monkeypatch.setattr('os.path.exists', lambda path: False)
+    monkeypatch.setattr('os.makedirs', lambda *args, **kwargs: None)
+
     mock_s3_downloader.download.return_value = False
 
     dataloader = DataLoader(config)
     result = dataloader.load_data("sqs", input_info)
 
-    # Verify that the method returns None upon download failure
-    assert result is None
+    assert result['data'] is None
+    metadata = result['metadata']
+    assert metadata['cleanup'] is True
+    assert metadata['key'] == input_info['key']
 
-def test_load_from_s3_unsupported_format(mocker, mock_s3_downloader, config, input_info):
-    # Mock the existence of the file to trigger the unsupported format path
-    mocker.patch('os.path.exists', return_value=True)
 
-    # Mock os.path.getsize to return a specific size, ensuring the file is considered existing and complete
-    mocker.patch('os.path.getsize', return_value=1234)
+def test_load_from_s3_unsupported_format(monkeypatch, mock_s3_downloader, config, input_info):
+    monkeypatch.setattr('os.path.exists', lambda path: True)
+    monkeypatch.setattr('os.path.getsize', lambda path: 1234)
+    monkeypatch.setattr('glob.glob', lambda pattern: [])
+    monkeypatch.setattr('os.makedirs', lambda *args, **kwargs: None)
 
-    # Mock glob.glob to simulate no partial files exist, if your logic includes checking for these
-    mocker.patch('glob.glob', return_value=[])
-
-    # Mock os.makedirs in case your logic includes creating directories
-    mocker.patch('os.makedirs', MagicMock())
-
-    # Assume the download was successful, which should not be reached due to the unsupported format logic
     mock_s3_downloader.download.return_value = True
-
-    # Mock opening of files to prevent actual file reads, adjust according to your logic inside the try-except block
-    mocker.patch('builtins.open', mocker.mock_open())
+    monkeypatch.setattr(DataLoader, '_load_local_file', lambda self, path: None)
 
     dataloader = DataLoader(config)
-    input_info['key'] += ".unsupported"  # Ensure the key ends with an unsupported format
+    input_info['key'] += ".unsupported"
     result = dataloader.load_data("sqs", input_info)
 
-    # Validate that the result indicates an unsupported file format
-    assert result == {"data": None, "metadata": {}}, "Expected unsupported format to result in no data and metadata"
+    assert result['data'] is None
+    metadata = result['metadata']
+    assert metadata['key'] == input_info['key']
+    assert metadata['relative_key'] == input_info['key']
 
 
+def test_load_from_file_reads_local_json(tmp_path):
+    root_path = tmp_path / "root"
+    root_path.mkdir()
+    nested_dir = root_path / "logs"
+    nested_dir.mkdir()
+    file_path = nested_dir / "sample.json"
+    sample_data = {"message": "hello"}
+    file_path.write_text(json.dumps(sample_data))
+
+    config = {
+        'file_settings': {
+            'root_path': str(root_path)
+        }
+    }
+
+    dataloader = DataLoader(config)
+    result = dataloader.load_data("file", {'file_path': str(file_path)})
+
+    assert result['data'] == sample_data
+    metadata = result['metadata']
+    assert metadata['file_path'] == str(file_path)
+    assert metadata['relative_key'] == os.path.relpath(file_path, root_path)
+    assert metadata['cleanup'] is False
+
+
+def test_load_from_sftp_reads_gzip(tmp_path):
+    root_path = tmp_path / "drop"
+    root_path.mkdir()
+    partner_dir = root_path / "partner"
+    partner_dir.mkdir()
+    file_path = partner_dir / "log.json.gz"
+    payload = {"status": "ok"}
+    with gzip.open(file_path, 'wt') as f:
+        json.dump(payload, f)
+
+    config = {
+        'sftp_settings': {
+            'drop_directory': str(root_path)
+        }
+    }
+
+    dataloader = DataLoader(config)
+    result = dataloader.load_data("sftp", {'file_path': str(file_path)})
+
+    assert result['data'] == payload
+    metadata = result['metadata']
+    assert metadata['file_path'] == str(file_path)
+    assert metadata['relative_key'] == os.path.relpath(file_path, root_path)
+    assert metadata['cleanup'] is False

--- a/tests/logging_agent/test_data_proccesor.py
+++ b/tests/logging_agent/test_data_proccesor.py
@@ -1,56 +1,133 @@
+import copy
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
+from logging_agent.cloud_waap import CloudWAAPProcessor
 from logging_agent.data_processor import DataProcessor
-from logging_agent.data_loader import DataLoader
-from logging_agent.transformer import Transformer
-from logging_agent.sender import Sender
-from logging_agent.downloader import S3Downloader  # Ensure this is the correct path
 
 
-@pytest.mark.parametrize("transformed_data", [
-    # Example list of dictionaries based on your provided JSON transformed_data
-    [{"time": "01 31 2024 13:14:51", "source_ip": "220.244.85.52", "source_port": 27855,
-      "destination_ip": "10.202.0.159", "destination_port": 443,
-      "protocol": "https", "http_method": "GET",
-      "host": "autodemo.radware.net", "request": "https://autodemo.radware.net/product/view?id=129",
-      "directory": "/product",
-      "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36 Edg/89.0.774.50",
-      "accept_language": "-",
-      "x-forwarded-for": "220.244.85.52",
-      "cookie": "AWSALB=L9ebhHi5PuXyus0wbQ1FOaExKgaDq; AWSALBCORS=L9ebhHi5LDuhfsHzIFqj9zHGEQ1FOaExKgaDq; PHPSESSID=si2233mfq8a1gvl5adl06glvm1; visited_products=%2C4223%2C50%2C127%2C67%%2C70%2C102C",
-      "request_time": "0.043", "response_code": 200, "http_bytes_in": 1445, "http_bytes_out": 10823,
-      "country_code": "AU", "action": "Allowed", "application_id": "805c88ac-aaf9-471a-9030-391c0393990d",
-      "application_name": "New CWAF Automated Demo", "tenant_name": "DEMO", "log_type": "Access",
-      "http_version": "HTTP/1.1", "uri": "/product/view"},
-     {"time": "01 31 2024 13:14:51", "source_ip": "95.21.225.67", "source_port": 24098,
-      "destination_ip": "10.202.0.159", "destination_port": 443, "protocol": "https",
-      "http_method": "GET", "host": "autodemo.radware.net", "request": "https://autodemo.radware.net/account",
-      "directory": "/", "user_agent": "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",
-      "accept_language": "en-US,en;q=0.9", "x-forwarded-for": "95.21.225.67",
-      "cookie": "AWSALB=L9ebhHi5PuXyus0wbQ1FOaExKgaDq; AWSALBCORS=L9ebhHi5LDuhfsHzIFqj9zHGEQ1FOaExKgaDq; PHPSESSID=si2233mfq8a1gvl5adl06glvm1; visited_products=%2C4223%2C50%2C127%2C67%%2C70%2C102C",
-      "request_time": "0.047", "response_code": 200, "http_bytes_in": 1723, "http_bytes_out": 7440,
-      "country_code": "ES", "action": "Allowed", "application_id": "805c88ac-aaf9-471a-9030-391c0393990d",
-      "application_name": "New CWAF Automated Demo", "tenant_name": "DEMO", "log_type": "Access",
-      "http_version": "HTTP/1.1", "uri": "/account"}]
-])
-
-
-
-def test_data_processor_process_data_success(data_processor, mock_dependencies, config_fixture,transformed_data):
+def test_data_processor_process_data_success(data_processor, mock_dependencies, config_fixture):
     input_fields = {
         'bucket': 'mock-bucket',
         'key': 'mock-key',
         'expected_size': 1234
     }
 
-    # Mock identify_product_log_type within DataProcessor to return a supported log type
-    with patch.object(DataProcessor, 'identify_product_log_type', return_value='Access'):
+    metadata = {
+        'file_path': '/tmp/mock-file',
+        'relative_key': 'relative/mock-key',
+        'cleanup': True
+    }
+    mock_dependencies['data_loader'].load_data.return_value = {
+        'data': [{'sample': 'data'}],
+        'metadata': metadata
+    }
+
+    with patch.object(DataProcessor, 'identify_product_log_type', return_value='Access') as identify_mock, \
+            patch.object(DataProcessor, 'gather_data_fields', return_value={'key': 'relative/mock-key'}) as gather_mock:
         success = data_processor.process_data(input_fields)
 
     assert success
     mock_dependencies['data_loader'].load_data.assert_called_once_with("sqs", input_fields)
-    mock_dependencies['transformer'].transform_content.assert_called_once()  # Verifies transformation was invoked
+    identify_args = identify_mock.call_args[0]
+    assert identify_args[1] == metadata
+    gather_args = gather_mock.call_args[0]
+    assert gather_args[1] == metadata
+    mock_dependencies['transformer'].transform_content.assert_called_once()
     mock_dependencies['sender_send_data'].assert_called_once()
+    mock_dependencies['utility_cleanup'].assert_called_once_with('/tmp/mock-file')
 
 
+def test_data_processor_process_data_skips_cleanup_without_flag(mock_dependencies, config_fixture):
+    config = copy.deepcopy(config_fixture)
+    config['type'] = 'file'
+    processor = DataProcessor(config)
 
+    metadata = {
+        'file_path': '/tmp/mock-file',
+        'relative_key': 'relative/mock-key',
+        'cleanup': False
+    }
+    mock_dependencies['data_loader'].load_data.return_value = {
+        'data': [{'sample': 'data'}],
+        'metadata': metadata
+    }
+
+    with patch.object(DataProcessor, 'identify_product_log_type', return_value='Access'), \
+            patch.object(DataProcessor, 'gather_data_fields', return_value={'key': 'relative/mock-key'}):
+        success = processor.process_data({'file_path': '/tmp/mock-file'})
+
+    assert success
+    mock_dependencies['utility_cleanup'].assert_not_called()
+
+
+def test_data_processor_process_data_skips_cleanup_on_failure(mock_dependencies, config_fixture):
+    config = copy.deepcopy(config_fixture)
+    processor = DataProcessor(config)
+
+    metadata = {
+        'file_path': '/tmp/mock-file',
+        'relative_key': 'relative/mock-key',
+        'cleanup': True
+    }
+    mock_dependencies['data_loader'].load_data.return_value = {
+        'data': [{'sample': 'data'}],
+        'metadata': metadata
+    }
+    mock_dependencies['sender_send_data'].return_value = False
+
+    with patch.object(DataProcessor, 'identify_product_log_type', return_value='Access'), \
+            patch.object(DataProcessor, 'gather_data_fields', return_value={'key': 'relative/mock-key'}):
+        success = processor.process_data({'key': 'mock-key'})
+
+    assert not success
+    mock_dependencies['utility_cleanup'].assert_not_called()
+
+
+@pytest.mark.parametrize('input_type', ['sqs', 'file', 'sftp'])
+def test_identify_product_log_type_uses_relative_key(config_fixture, input_type):
+    processor = DataProcessor(config_fixture)
+    metadata = {'relative_key': 'relative/path'}
+    with patch.object(CloudWAAPProcessor, 'identify_log_type', return_value='Access') as identify_mock:
+        log_type = processor.identify_product_log_type({'key': 'fallback'}, metadata, input_type, 'cloud_waap')
+
+    assert log_type == 'Access'
+    identify_mock.assert_called_once_with('relative/path')
+
+
+def test_identify_product_log_type_falls_back_to_input_fields(config_fixture):
+    processor = DataProcessor(config_fixture)
+    metadata = {}
+    with patch.object(CloudWAAPProcessor, 'identify_log_type', return_value='Access') as identify_mock:
+        log_type = processor.identify_product_log_type({'key': 'fallback'}, metadata, 'sqs', 'cloud_waap')
+
+    assert log_type == 'Access'
+    identify_mock.assert_called_once_with('fallback')
+
+
+def test_gather_data_fields_uses_relative_key(config_fixture):
+    processor = DataProcessor(config_fixture)
+    metadata = {'relative_key': 'relative/path'}
+    with patch.object(CloudWAAPProcessor, 'extract_metadata', return_value={'meta': 'data'}) as extract_mock:
+        data_fields = processor.gather_data_fields({}, metadata, 'file', 'Access', 'cloud_waap')
+
+    assert data_fields['key'] == 'relative/path'
+    assert data_fields['metadata'] == {'meta': 'data'}
+    extract_mock.assert_called_once_with('relative/path', 'cloud_waap', 'Access')
+
+
+def test_gather_data_fields_falls_back_to_input_fields(config_fixture):
+    processor = DataProcessor(config_fixture)
+    metadata = {}
+    with patch.object(CloudWAAPProcessor, 'extract_metadata', return_value={'meta': 'data'}) as extract_mock:
+        data_fields = processor.gather_data_fields({'key': 'fallback'}, metadata, 'sqs', 'Access', 'cloud_waap')
+
+    assert data_fields['key'] == 'fallback'
+    extract_mock.assert_called_once_with('fallback', 'cloud_waap', 'Access')
+
+
+def test_gather_data_fields_non_cloud_product(config_fixture):
+    processor = DataProcessor(config_fixture)
+    result = processor.gather_data_fields({}, {}, 'sqs', 'Access', 'other_product')
+    assert result == {}


### PR DESCRIPTION
## Summary
- add dispatching in the data loader to handle file and sftp sources using a shared local file reader
- include relative keys and cleanup flags in loader metadata and consume them in the data processor
- expand unit tests to cover the new inputs and cleanup semantics

## Testing
- RLA_VERIFY_MODE=1 PYTHONPATH=src pytest tests/logging_agent/test_data_loader.py tests/logging_agent/test_data_proccesor.py

------
https://chatgpt.com/codex/tasks/task_b_690087d292dc83209f82b7ad3a688cf5