### PR TITLE
Add file and SFTP ingestion agents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,10 @@ When exposing the built-in SFTP drop-zone, harden the deployment:
 - Prefer the `public_key` credential policy with per-partner keys; if passwords are required, rotate them regularly and deliver through a secrets manager.
 - Place `drop_directory` on a filesystem with adequate quotas and ensure it is not world-writable. Create per-tenant subdirectories with appropriate ownership.
 - Use network controls (firewalls, security groups) to restrict inbound SFTP access to approved partners.
+- Run the agent as a service user that owns the `drop_directory` and archive targets. Remove write access for other system accounts and disable shell access for the service user.
+- Protect private host key files with `chmod 600` and restrict access to the service account only. Maintain a rotation schedule and monitor for unauthorized changes.
+- Store static passwords or authorized-key material in a secure secrets manager. Inject values at runtime via environment variables or orchestration tools so that plain-text credentials never live in the image or repository.
+- Enable OS-level auditing on the drop directory so upload attempts, failures, and clean-up actions are logged centrally.
 
 ## Output Configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML~=6.0.1
 ua-parser~=0.18.0
 user-agents~=2.2.0
 certifi~=2024.8.30
+asyncssh~=2.21.1

--- a/src/logging_agent/file_agent.py
+++ b/src/logging_agent/file_agent.py
@@ -65,7 +65,7 @@ class FileQueueAgent:
                 entry = self.processing_queue.get(timeout=1)
             except queue.Empty:
                 if self.stop_event.is_set():
-                    continue
+                    break
                 continue
 
             if entry is None:

--- a/src/logging_agent/file_agent.py
+++ b/src/logging_agent/file_agent.py
@@ -1,0 +1,254 @@
+import os
+import queue
+import shutil
+import threading
+from typing import Dict, Optional, Tuple
+
+from .data_processor import DataProcessor
+from .logging_config import get_logger
+
+
+class FileQueueAgent:
+    """Common queue and worker management for file-based agents."""
+
+    def __init__(
+        self,
+        agent_config: dict,
+        root_path: str,
+        completion_strategy: Optional[dict],
+        input_type: str,
+    ) -> None:
+        if not root_path:
+            raise ValueError("root_path is required for file-based agents")
+
+        self.agent_config = agent_config
+        self.input_type = input_type
+        self.root_path = os.path.abspath(root_path)
+        self.logger = get_logger(self.__class__.__name__)
+        self.data_processor = DataProcessor(agent_config)
+        self.processing_queue: "queue.Queue[Optional[dict]]" = queue.Queue()
+        self.stop_event = threading.Event()
+        self.worker_threads: list[threading.Thread] = []
+        self._known_files: Dict[str, Tuple[int, float]] = {}
+        self._inflight_files: set[str] = set()
+        self._lock = threading.Lock()
+        self.completion_strategy = self._normalize_completion_strategy(completion_strategy)
+
+    @staticmethod
+    def _normalize_completion_strategy(completion_strategy: Optional[dict]) -> dict:
+        if completion_strategy is None:
+            return {"mode": "delete"}
+        if isinstance(completion_strategy, str):
+            return {"mode": completion_strategy}
+
+        strategy = dict(completion_strategy)
+        mode = strategy.get("mode", "delete").lower()
+        normalized = {"mode": mode}
+        if mode == "archive":
+            archive_directory = strategy.get("archive_directory")
+            if not archive_directory:
+                raise ValueError("archive_directory must be provided for archive mode")
+            normalized["archive_directory"] = os.path.abspath(archive_directory)
+        return normalized
+
+    def _start_worker_threads(self) -> None:
+        num_threads = self.agent_config.get("num_worker_threads", 1)
+        for index in range(num_threads):
+            thread = threading.Thread(target=self._worker_loop, name=f"{self.input_type}-worker-{index}")
+            thread.daemon = True
+            thread.start()
+            self.worker_threads.append(thread)
+
+    def _worker_loop(self) -> None:
+        while True:
+            try:
+                entry = self.processing_queue.get(timeout=1)
+            except queue.Empty:
+                if self.stop_event.is_set():
+                    continue
+                continue
+
+            if entry is None:
+                self.processing_queue.task_done()
+                break
+
+            try:
+                self._process_queue_entry(entry)
+            except Exception:  # pragma: no cover - defensive logging
+                self.logger.exception("Unexpected error processing entry %s", entry)
+            finally:
+                self.processing_queue.task_done()
+
+    def _process_queue_entry(self, entry: dict) -> bool:
+        file_path = entry["file_path"]
+        success = False
+        try:
+            success = self.data_processor.process_data(
+                {
+                    "file_path": file_path,
+                    "key": entry["relative_key"],
+                    "expected_size": entry.get("size"),
+                }
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            self.logger.exception("DataProcessor raised an exception for %s", file_path)
+        finally:
+            self._finalize_entry(entry, success)
+        return success
+
+    def _finalize_entry(self, entry: dict, success: bool) -> None:
+        file_path = entry["file_path"]
+        if success:
+            self._handle_success_cleanup(entry)
+            with self._lock:
+                self._inflight_files.discard(file_path)
+                self._known_files.pop(file_path, None)
+        else:
+            with self._lock:
+                self._inflight_files.discard(file_path)
+            self._reset_tracking_state(file_path)
+
+    def _handle_success_cleanup(self, entry: dict) -> None:
+        mode = self.completion_strategy.get("mode", "delete")
+        file_path = entry["file_path"]
+
+        if mode == "delete":
+            try:
+                os.remove(file_path)
+                self.logger.debug("Deleted processed file %s", file_path)
+            except FileNotFoundError:
+                self.logger.debug("File %s already removed", file_path)
+            except OSError as exc:
+                self.logger.error("Failed to delete %s: %s", file_path, exc)
+        elif mode == "archive":
+            archive_directory = self.completion_strategy["archive_directory"]
+            destination = os.path.join(archive_directory, entry["relative_key"])
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            try:
+                shutil.move(file_path, destination)
+                self.logger.debug("Archived %s to %s", file_path, destination)
+            except FileNotFoundError:
+                self.logger.debug("File %s missing before archive", file_path)
+            except OSError as exc:
+                self.logger.error("Failed to archive %s: %s", file_path, exc)
+
+    def _reset_tracking_state(self, file_path: str) -> None:
+        try:
+            stat_result = os.stat(file_path)
+        except OSError:
+            with self._lock:
+                self._known_files.pop(file_path, None)
+            return
+
+        with self._lock:
+            self._known_files[file_path] = (stat_result.st_size, stat_result.st_mtime)
+
+    def _await_worker_completion(self) -> None:
+        self.processing_queue.join()
+        for _ in self.worker_threads:
+            self.processing_queue.put(None)
+        for thread in self.worker_threads:
+            thread.join(timeout=10)
+            if thread.is_alive():
+                self.logger.warning("Worker thread %s did not exit cleanly", thread.name)
+
+    def stop(self) -> None:
+        self.stop_event.set()
+
+    def _queue_file(self, file_path: str, size: Optional[int] = None) -> bool:
+        absolute_path = os.path.abspath(file_path)
+        if not self._is_within_root(absolute_path):
+            self.logger.warning("Ignoring path outside root: %s", absolute_path)
+            return False
+
+        if size is None:
+            try:
+                size = os.path.getsize(absolute_path)
+            except OSError as exc:
+                self.logger.error("Unable to stat %s: %s", absolute_path, exc)
+                return False
+
+        relative_key = os.path.relpath(absolute_path, self.root_path)
+        with self._lock:
+            if absolute_path in self._inflight_files:
+                return False
+            self._inflight_files.add(absolute_path)
+            self._known_files.pop(absolute_path, None)
+
+        entry = {
+            "input_type": self.input_type,
+            "file_path": absolute_path,
+            "relative_key": relative_key,
+            "size": size,
+        }
+        self.processing_queue.put(entry)
+        self.logger.info("Enqueued file %s (%d bytes)", relative_key, size)
+        return True
+
+    def _is_within_root(self, absolute_path: str) -> bool:
+        root = self.root_path
+        if not absolute_path.startswith(root):
+            return False
+        # Ensure directories like /tmp/root-other don't match
+        return os.path.commonpath([root, absolute_path]) == root
+
+    def _scan_for_files(self) -> None:
+        for current_root, _dirs, files in os.walk(self.root_path):
+            for filename in files:
+                candidate = os.path.join(current_root, filename)
+                try:
+                    stat_result = os.stat(candidate)
+                except OSError:
+                    continue
+
+                file_signature = (stat_result.st_size, stat_result.st_mtime)
+                with self._lock:
+                    if candidate in self._inflight_files:
+                        continue
+                    previous = self._known_files.get(candidate)
+                    if previous == file_signature:
+                        should_queue = True
+                        self._known_files.pop(candidate, None)
+                    else:
+                        self._known_files[candidate] = file_signature
+                        should_queue = False
+
+                if should_queue:
+                    self._queue_file(candidate, size=stat_result.st_size)
+
+        # Remove stale entries for files that disappeared
+        with self._lock:
+            stale = [path for path in self._known_files if not os.path.exists(path)]
+            for path in stale:
+                self._known_files.pop(path, None)
+                self._inflight_files.discard(path)
+
+
+class FileAgent(FileQueueAgent):
+    """Agent that polls a directory for completed files."""
+
+    def __init__(self, agent_config: dict) -> None:
+        settings = agent_config.get("file_settings", {})
+        completion = settings.get("completion_strategy")
+        super().__init__(
+            agent_config,
+            root_path=settings.get("root_path", ""),
+            completion_strategy=completion,
+            input_type="file",
+        )
+        self.polling_interval = int(settings.get("polling_interval_seconds", 5))
+
+    def start(self) -> None:
+        self.logger.info("Starting FileAgent for %s", self.root_path)
+        self._start_worker_threads()
+        try:
+            while not self.stop_event.is_set():
+                self._scan_for_files()
+                self.stop_event.wait(self.polling_interval)
+        finally:
+            self.logger.debug("FileAgent scan loop exiting")
+
+        # One final scan to pick up any files that stabilized during shutdown
+        self._scan_for_files()
+        self._await_worker_completion()
+        self.logger.info("FileAgent stopped for %s", self.root_path)

--- a/src/logging_agent/local_agent.py
+++ b/src/logging_agent/local_agent.py
@@ -1,5 +1,8 @@
 import threading
 import time
+
+from .file_agent import FileAgent
+from .sftp_agent import SFTPAgent
 from .sqs_agent import SQSAgent  # Adjust import as needed
 from .config_reader import Config
 from .logging_config import get_logger
@@ -14,13 +17,24 @@ logger = get_logger('local_agent')
 def start_agents(agents_config):
     """Starts multiple agents based on their configurations."""
     agents = []
+    agent_factories = {
+        'sqs': SQSAgent,
+        'file': FileAgent,
+        'sftp': SFTPAgent,
+    }
+
     for agent_config in agents_config:
         agent_type = agent_config.get('type')
-        if agent_type == 'sqs':
-            agent = SQSAgent(agent_config)
-        else:
+        agent_cls = agent_factories.get(agent_type)
+        if not agent_cls:
             logger.error(f"Unsupported agent type: {agent_type}")
             continue  # Skip unsupported agent types
+
+        try:
+            agent = agent_cls(agent_config)
+        except ImportError as exc:
+            logger.error(f"Unable to start {agent_type} agent {agent_config.get('name')}: {exc}")
+            continue
 
         agent_thread = threading.Thread(target=agent.start)
         agent_thread.daemon = True

--- a/src/logging_agent/sftp_agent.py
+++ b/src/logging_agent/sftp_agent.py
@@ -1,6 +1,4 @@
 import asyncio
-import asyncio
-import asyncio
 import os
 from typing import Dict, List, Optional, TYPE_CHECKING
 

--- a/src/logging_agent/sftp_agent.py
+++ b/src/logging_agent/sftp_agent.py
@@ -1,0 +1,248 @@
+import asyncio
+import asyncio
+import asyncio
+import os
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+from .file_agent import FileQueueAgent
+
+try:  # pragma: no cover - optional dependency imported lazily
+    import asyncssh
+    from asyncssh import sftp as asyncssh_sftp
+except ImportError:  # pragma: no cover - handled gracefully in start()
+    asyncssh = None
+    asyncssh_sftp = None
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    import asyncssh as asyncssh_module
+
+
+if asyncssh_sftp is not None:
+
+    class _TrackedFile(asyncssh_sftp.LocalFile):
+        """Wrap AsyncSSH LocalFile to trigger callbacks when uploads finish."""
+
+        def __init__(self, agent: "SFTPAgent", relative_path: str, file_obj):
+            super().__init__(file_obj)
+            self._agent = agent
+            self._relative_path = relative_path
+
+        async def close(self) -> None:  # pragma: no cover - exercised via agent logic
+            await super().close()
+            try:
+                self._agent._handle_upload_complete(self._relative_path)
+            except Exception:
+                self._agent.logger.exception("Failed to enqueue uploaded file %s", self._relative_path)
+
+else:  # pragma: no cover - ensures module imports even without asyncssh
+
+    class _TrackedFile:  # type: ignore[too-many-ancestors]
+        pass
+
+
+class SFTPAgent(FileQueueAgent):
+    """Run an embedded SFTP service and enqueue completed uploads."""
+
+    def __init__(self, agent_config: dict) -> None:
+        if asyncssh is None:
+            raise ImportError("asyncssh is required for the SFTPAgent")
+
+        settings = agent_config.get("sftp_settings", {})
+        completion = settings.get("completion_strategy")
+        drop_directory = settings.get("drop_directory", "")
+        super().__init__(
+            agent_config,
+            root_path=drop_directory,
+            completion_strategy=completion,
+            input_type="sftp",
+        )
+
+        listen_settings = settings.get("listen", {})
+        self.listen_host = listen_settings.get("host", "")
+        self.listen_port = int(listen_settings.get("port", 0))
+        self.host_keys = settings.get("host_keys", [])
+        self.polling_interval = int(settings.get("polling_interval_seconds", 5))
+
+        self.credential_policy = settings.get("credential_policy", {})
+        self.credential_mode = (self.credential_policy.get("mode") or "static").lower()
+
+        self._static_passwords: Dict[str, str] = {}
+        self._public_keys: Dict[str, List["asyncssh_module.SSHKey"]] = {}
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._shutdown_event: Optional[asyncio.Event] = None
+        self._server: Optional["asyncssh_module.SSHAcceptor"] = None
+
+        self._parse_credentials()
+
+    def _parse_credentials(self) -> None:
+        users = self.credential_policy.get("users", [])
+        if self.credential_mode == "static":
+            self._static_passwords = {
+                user["username"]: user["password"]
+                for user in users
+                if user.get("username") and user.get("password")
+            }
+        elif self.credential_mode == "public_key":
+            key_map: Dict[str, List["asyncssh_module.SSHKey"]] = {}
+            for user in users:
+                username = user.get("username")
+                if not username:
+                    continue
+                keys = []
+                for entry in user.get("authorized_keys", []):
+                    try:
+                        keys.append(asyncssh.import_public_key(entry))
+                    except Exception as exc:  # pragma: no cover - defensive logging
+                        self.logger.error("Invalid authorized key for %s: %s", username, exc)
+                if keys:
+                    key_map[username] = keys
+            self._public_keys = key_map
+        else:
+            raise ValueError(f"Unsupported credential mode: {self.credential_mode}")
+
+    def start(self) -> None:
+        self.logger.info("Starting SFTPAgent on %s:%s", self.listen_host or "0.0.0.0", self.listen_port)
+        self._start_worker_threads()
+
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._shutdown_event = asyncio.Event()
+
+        try:
+            self._loop.run_until_complete(self._serve())
+        finally:
+            try:
+                self._loop.run_until_complete(self._loop.shutdown_asyncgens())
+            finally:
+                asyncio.set_event_loop(None)
+                self._loop.close()
+                self._loop = None
+
+        # Drain any remaining files discovered during shutdown
+        self._scan_for_files()
+        self._await_worker_completion()
+        self.logger.info("SFTPAgent stopped for %s", self.root_path)
+
+    async def _serve(self) -> None:
+        assert asyncssh is not None
+        assert self._shutdown_event is not None
+
+        server_kwargs = {
+            "host": self.listen_host,
+            "port": self.listen_port,
+            "server_factory": self._create_ssh_server_factory(),
+            "server_host_keys": self.host_keys,
+            "sftp_factory": self._create_sftp_server,
+            "allow_scp": False,
+            "process_factory": None,
+            "session_factory": None,
+            "password_auth": self.credential_mode == "static",
+            "public_key_auth": self.credential_mode == "public_key",
+        }
+
+        self._server = await asyncssh.listen(**server_kwargs)
+        self.logger.info("SFTP server listening on port %s", self._server.get_port())
+
+        while not self.stop_event.is_set():
+            self._scan_for_files()
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=self.polling_interval)
+                break
+            except asyncio.TimeoutError:
+                continue
+
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+
+    def stop(self) -> None:
+        self.logger.info("Stopping SFTPAgent for %s", self.root_path)
+        super().stop()
+        if self._loop and self._shutdown_event:
+            self._loop.call_soon_threadsafe(self._shutdown_event.set)
+
+    def _create_ssh_server_factory(self):
+        agent = self
+
+        class _SFTPSSHServer(asyncssh.SSHServer):
+            def connection_made(self, conn):  # pragma: no cover - authentication only
+                self._conn = conn
+
+            def password_auth_supported(self) -> bool:
+                return agent.credential_mode == "static"
+
+            async def validate_password(self, username: str, password: str) -> bool:
+                expected = agent._static_passwords.get(username)
+                return expected is not None and expected == password
+
+            def public_key_auth_supported(self) -> bool:
+                return agent.credential_mode == "public_key"
+
+            async def validate_public_key(self, username: str, key: "asyncssh_module.SSHKey") -> bool:
+                allowed = agent._public_keys.get(username, [])
+                return any(key == candidate for candidate in allowed)
+
+        return _SFTPSSHServer
+
+    def _create_sftp_server(self, chan: "asyncssh_module.SSHServerChannel") -> "asyncssh_module.SFTPServer":
+        agent = self
+
+        class _UploadAwareServer(asyncssh.SFTPServer):
+            def __init__(self, channel):
+                super().__init__(channel, chroot=os.fsencode(agent.root_path))
+
+            def open(self, path, pflags, attrs):
+                file_obj = super().open(path, pflags, attrs)
+                if not agent._is_write_mode(pflags):
+                    return file_obj
+                relative = os.fsdecode(path)
+                return _TrackedFile(agent, relative, file_obj)
+
+            def open56(self, path, desired_access, flags, attrs):  # pragma: no cover - depends on client version
+                file_obj = super().open56(path, desired_access, flags, attrs)
+                if not agent._is_write_mode_v56(desired_access, flags):
+                    return file_obj
+                relative = os.fsdecode(path)
+                return _TrackedFile(agent, relative, file_obj)
+
+        return _UploadAwareServer(chan)
+
+    def _is_write_mode(self, pflags: int) -> bool:
+        write_flags = (
+            asyncssh_sftp.FXF_WRITE
+            | asyncssh_sftp.FXF_CREAT
+            | asyncssh_sftp.FXF_TRUNC
+            | asyncssh_sftp.FXF_APPEND
+        )
+        return bool(pflags & write_flags)
+
+    def _is_write_mode_v56(self, desired_access: int, flags: int) -> bool:
+        if desired_access & (asyncssh_sftp.ACE4_WRITE_DATA | asyncssh_sftp.ACE4_APPEND_DATA):
+            return True
+        disposition = flags & asyncssh_sftp.FXF_ACCESS_DISPOSITION
+        return disposition in {
+            asyncssh_sftp.FXF_CREATE_NEW,
+            asyncssh_sftp.FXF_CREATE_TRUNCATE,
+            asyncssh_sftp.FXF_OPEN_OR_CREATE,
+            asyncssh_sftp.FXF_TRUNCATE_EXISTING,
+        }
+
+    def _resolve_relative_path(self, relative_path: str) -> str:
+        normalized = os.path.normpath(relative_path).lstrip(os.sep)
+        absolute = os.path.abspath(os.path.join(self.root_path, normalized))
+        if not self._is_within_root(absolute):
+            raise ValueError(f"Upload path {relative_path} escapes drop directory")
+        return absolute
+
+    def _handle_upload_complete(self, relative_path: str) -> None:
+        try:
+            absolute_path = self._resolve_relative_path(relative_path)
+        except ValueError as exc:
+            self.logger.error("Rejected upload outside drop directory: %s", exc)
+            return
+
+        if not os.path.exists(absolute_path):
+            self.logger.debug("Uploaded path no longer exists: %s", absolute_path)
+            return
+
+        self._queue_file(absolute_path)

--- a/src/logging_agent/sqs_agent.py
+++ b/src/logging_agent/sqs_agent.py
@@ -2,10 +2,10 @@ import boto3
 import threading
 import queue
 import json
+import time
 from .data_processor import DataProcessor
 from .logging_config import get_logger
 import urllib.parse
-import time
 
 class SQSAgent:
     def __init__(self, agent_config):
@@ -15,6 +15,7 @@ class SQSAgent:
         self.data_processor = DataProcessor(agent_config)
         self.processing_queue = queue.Queue()
         self.stop_event = threading.Event()
+        self.worker_threads: list[threading.Thread] = []
 
     def get_sqs_client(self, config):
         """
@@ -70,14 +71,21 @@ class SQSAgent:
             processing_messages (queue.Queue): Queue from which to retrieve and process messages.
             stop_agent (threading.Event): Event to signal when to stop the worker.
         """
-        while not stop_agent.is_set():
-            message_retrieved = False
+        while True:
             try:
                 message_details = processing_messages.get(timeout=3)
-                message_retrieved = True  # Flag set as a message has been successfully retrieved
-                self.logger.debug(f"Worker picked up message: {message_details}")
+            except queue.Empty:
+                if stop_agent.is_set():
+                    break
+                continue
 
-                # Handle SQS-specific processing
+            if message_details is None:
+                processing_messages.task_done()
+                break
+
+            self.logger.debug(f"Worker picked up message: {message_details}")
+
+            try:
                 process_success = self.data_processor.process_data(
                     input_fields={
                         'bucket': message_details['bucket'],
@@ -85,16 +93,16 @@ class SQSAgent:
                         'expected_size': message_details['size'],
                     }
                 )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self.logger.error("Failed to process SQS message %s: %s", message_details, exc)
+                process_success = False
 
-                # Handle message deletion based on processing success and config settings
-                if process_success or (not process_success and self.agent_config['sqs_settings']['delete_on_failure']):
-                    self.delete_message_from_sqs(message_details['receipt_handle'])
+            if process_success or (
+                not process_success and self.agent_config['sqs_settings']['delete_on_failure']
+            ):
+                self.delete_message_from_sqs(message_details['receipt_handle'])
 
-            except queue.Empty:
-                self.logger.debug("No messages in queue.")
-
-            if message_retrieved:
-                processing_messages.task_done()
+            processing_messages.task_done()
 
     def poll_sqs_messages(self, processing_messages, stop_agent):
         """
@@ -133,25 +141,25 @@ class SQSAgent:
     def start(self):
         """Starts the SQS agent processing."""
         self.logger.debug(f"Starting SQS Agent: {self.agent_config['name']}")
-        for _ in range(self.agent_config['num_worker_threads']):
-            t = threading.Thread(target=self.worker, args=(self.processing_queue, self.stop_event))
+        for index in range(self.agent_config['num_worker_threads']):
+            t = threading.Thread(
+                target=self.worker,
+                name=f"sqs-worker-{index}",
+                args=(self.processing_queue, self.stop_event),
+            )
             t.daemon = True
             t.start()
+            self.worker_threads.append(t)
 
         self.poll_sqs_messages(self.processing_queue, self.stop_event)
-
 
     def stop(self):
         self.logger.info(f"Stopping SQSAgent: {self.agent_config['name']}")
         self.stop_event.set()  # Signal the workers to stop
 
-        # Attempt a graceful shutdown with a timeout
-        shutdown_start_time = time.time()
-        shutdown_timeout = 60  # seconds
-        while time.time() - shutdown_start_time < shutdown_timeout:
-            if self.processing_queue.empty():
-                self.logger.info(f"SQSAgent {self.agent_config['name']} stopped successfully.")
-                return
-            time.sleep(0.5)  # Short sleep to allow threads to exit
-
-        self.logger.warning(f"SQSAgent {self.agent_config['name']} shutdown timed out. Some tasks may not have completed.")
+        # Allow workers to finish current tasks
+        self.processing_queue.join()
+        for thread in self.worker_threads:
+            thread.join(timeout=10)
+            if thread.is_alive():
+                self.logger.warning("SQS worker thread %s did not exit cleanly", thread.name)

--- a/src/rla.yaml
+++ b/src/rla.yaml
@@ -1,0 +1,24 @@
+general:
+  log_file: /tmp/rla.log
+  output_directory: /tmp
+  log_directory: /tmp
+  logging_levels: INFO
+aws_credentials:
+  access_key_id: test
+  secret_access_key: test
+  region: us-east-1
+output:
+  type: tcp
+  destination: 127.0.0.1
+  port: 514
+  output_format: json
+  batch: false
+  compatibility_mode: none
+formats:
+  json: {}
+http: {}
+https: {}
+debug:
+  verify_destination_connectivity: false
+  config_verification: false
+agents: []

--- a/tests/logging_agent/test_file_and_sftp_agents.py
+++ b/tests/logging_agent/test_file_and_sftp_agents.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from logging_agent.file_agent import FileAgent
+from logging_agent.sftp_agent import SFTPAgent
+
+
+@pytest.fixture
+def file_agent_config(tmp_path: Path) -> dict:
+    root = tmp_path / "logs"
+    root.mkdir()
+    return {
+        'name': 'file-agent',
+        'type': 'file',
+        'num_worker_threads': 1,
+        'file_settings': {
+            'root_path': str(root),
+            'polling_interval_seconds': 0,
+            'completion_strategy': {'mode': 'delete'},
+        },
+    }
+
+
+def test_file_agent_enqueues_completed_file(tmp_path: Path, file_agent_config: dict) -> None:
+    agent = FileAgent(file_agent_config)
+    agent.data_processor.process_data = MagicMock(return_value=True)
+
+    target_file = Path(file_agent_config['file_settings']['root_path']) / 'sample.json'
+    target_file.write_text('{"example": true}')
+
+    # First scan records the file, second scan confirms it is stable
+    agent._scan_for_files()
+    agent._scan_for_files()
+
+    entry = agent.processing_queue.get_nowait()
+    assert entry['input_type'] == 'file'
+    assert entry['relative_key'] == 'sample.json'
+    assert Path(entry['file_path']).resolve() == target_file.resolve()
+
+    agent._process_queue_entry(entry)
+    agent.data_processor.process_data.assert_called_once()
+    assert not target_file.exists()
+
+
+@pytest.fixture
+def sftp_agent_config(tmp_path: Path) -> dict:
+    drop_dir = tmp_path / "drop"
+    drop_dir.mkdir()
+    host_key = tmp_path / "ssh_host_key"
+    host_key.write_text("dummy")
+    return {
+        'name': 'sftp-agent',
+        'type': 'sftp',
+        'num_worker_threads': 1,
+        'sftp_settings': {
+            'listen': {'host': '127.0.0.1', 'port': 0},
+            'host_keys': [str(host_key)],
+            'drop_directory': str(drop_dir),
+            'polling_interval_seconds': 0,
+            'completion_strategy': {'mode': 'delete'},
+            'credential_policy': {
+                'mode': 'static',
+                'users': [{'username': 'upload', 'password': 'secret'}],
+            },
+        },
+    }
+
+
+def test_sftp_agent_upload_callback(tmp_path: Path, sftp_agent_config: dict) -> None:
+    agent = SFTPAgent(sftp_agent_config)
+    agent.data_processor.process_data = MagicMock(return_value=True)
+
+    target_file = Path(sftp_agent_config['sftp_settings']['drop_directory']) / 'folder' / 'event.json'
+    target_file.parent.mkdir()
+    target_file.write_text('{"value": 1}')
+
+    agent._handle_upload_complete('folder/event.json')
+
+    entry = agent.processing_queue.get_nowait()
+    assert entry['input_type'] == 'sftp'
+    assert entry['relative_key'] == 'folder/event.json'
+
+    agent._process_queue_entry(entry)
+    agent.data_processor.process_data.assert_called_once()
+    assert not target_file.exists()


### PR DESCRIPTION
## Summary
- add a reusable file queue agent and FileAgent implementation for filesystem ingestion and cleanup
- introduce an AsyncSSH-based SFTPAgent and register the new agents in the local runner alongside improved SQS shutdown handling
- document SFTP hardening guidance, add focused unit tests, sample config, and declare the asyncssh dependency

## Testing
- PYTHONPATH=src pytest tests/logging_agent/test_file_and_sftp_agents.py tests/logging_agent/test_sqs_agent.py

------
https://chatgpt.com/codex/tasks/task_b_69008ad11a00832094a094eeb7c2eb01