### PR TITLE
Allow Cloud WAAP agents to optionally process unknown log types

### DIFF
--- a/config/rla.yaml
+++ b/config/rla.yaml
@@ -46,6 +46,7 @@ agents:
       DDoS: true  # Enable or disable ingestion of 'DDoS' logs.
       WebDDoS: true  # Enable or disable ingestion of 'WebDDoS' logs.
       CSP: true  # Enable or disable ingestion of 'CSP' logs.
+      unknown: false  # Enable processing for logs whose type is not yet recognized.
 
   # Example: Local file system agent for processing dropped log files
   # - name: "local-files"

--- a/src/logging_agent/app_info.py
+++ b/src/logging_agent/app_info.py
@@ -9,6 +9,9 @@ supported_features = {
         },
         "supported_conversions": ['cef', 'leef', "json"],
         "supported_log_types": ['CSP', "Access", "WAF", "Bot", "DDoS", "WebDDoS"],
+        "log_configuration": {
+            "unknown_option": "unknown"
+        },
         "supported_input_type": ['sqs', 'file', 'sftp'],
         "input_type_requirements": {
             "file": {

--- a/src/logging_agent/config_reader.py
+++ b/src/logging_agent/config_reader.py
@@ -268,6 +268,15 @@ class Config:
         agent_type = (agent.get('type') or '').lower()
         product = agent.get('product')
 
+        logs = agent.get('logs') or {}
+        if not isinstance(logs, dict):
+            logs = {}
+        log_configuration = supported_features.get(product or 'cloud_waap', {}).get('log_configuration', {})
+        unknown_option = log_configuration.get('unknown_option')
+        if unknown_option and unknown_option not in logs:
+            logs[unknown_option] = False
+        agent['logs'] = logs
+
         if agent_type == 'file':
             file_settings = agent.get('file_settings', {}) or {}
             root_path = file_settings.get('root_path')

--- a/src/logging_agent/config_verification.py
+++ b/src/logging_agent/config_verification.py
@@ -392,10 +392,14 @@ def verify_agent_config(agent_config):
 
     # Verify log types for the agent
     supported_log_types = supported_features[product]['supported_log_types']
+    log_configuration = supported_features[product].get('log_configuration', {})
+    unknown_option = log_configuration.get('unknown_option')
     for log_type, enabled in agent_config.get('logs', {}).items():
         if not isinstance(enabled, bool):
             logger.error(f"Invalid value for log type '{log_type}' in agent {agent_config['name']}. Should be a boolean.")
             return False
+        if unknown_option and log_type == unknown_option:
+            continue
         if log_type not in supported_log_types:
             logger.error(f"Unsupported log type: {log_type} for product: {product} in agent {agent_config['name']}")
             return False

--- a/src/logging_agent/data_processor.py
+++ b/src/logging_agent/data_processor.py
@@ -51,14 +51,23 @@ class DataProcessor:
             self.logger.error(f"Failed to load data for input type: {input_type}")
             return False
 
-        log_type = self.identify_product_log_type(input_fields, metadata, input_type, product)
-        # Check if the log type is supported for the product
-        if log_type not in supported_features[product]["supported_log_types"]:
-            self.logger.info(f"Skipping unsupported log type {log_type} for product {product}.")
-            return True  # Successfully handled by skipping
+        log_type = self.identify_product_log_type(input_fields, metadata, input_type, product) or "Unknown"
+        supported_log_types = supported_features[product]["supported_log_types"]
+        logs_config = self.config.get('logs', {}) or {}
+        log_configuration = supported_features.get(product, {}).get('log_configuration', {})
+        unknown_option = log_configuration.get('unknown_option')
+        allow_unknown_logs = logs_config.get(unknown_option, False) if unknown_option else False
 
-        # Check if the log type should be processed based on configuration
-        if not self.config.get('logs', {}).get(log_type, False):
+        # Check if the log type is supported for the product
+        if log_type not in supported_log_types:
+            if not allow_unknown_logs:
+                self.logger.info(f"Skipping unsupported log type {log_type} for product {product}.")
+                return True  # Successfully handled by skipping
+            self.logger.info(
+                f"Processing unsupported log type {log_type} for product {product} because unknown logs are enabled."
+            )
+        elif not logs_config.get(log_type, False):
+            # Check if the log type should be processed based on configuration
             self.logger.info(f"Skipping log type {log_type} as per configuration.")
             return True  # Successfully handled by skipping
 

--- a/tests/logging_agent/conftest.py
+++ b/tests/logging_agent/conftest.py
@@ -31,7 +31,8 @@ def config():
             'delete_on_failure': True
         },
         "logs": {
-            "Access": True
+            "Access": True,
+            "unknown": False
         }
     }
 
@@ -135,7 +136,8 @@ def config_fixture():
             'delete_on_failure': True
         },
         "logs": {
-            "Access": True
+            "Access": True,
+            "unknown": False
         },
         "tcp": {
             "batch": False

--- a/tests/logging_agent/test_data_proccesor.py
+++ b/tests/logging_agent/test_data_proccesor.py
@@ -131,3 +131,65 @@ def test_gather_data_fields_non_cloud_product(config_fixture):
     processor = DataProcessor(config_fixture)
     result = processor.gather_data_fields({}, {}, 'sqs', 'Access', 'other_product')
     assert result == {}
+
+
+def test_process_data_skips_unknown_type_when_flag_disabled(mock_dependencies, config_fixture):
+    config = copy.deepcopy(config_fixture)
+    config['logs']['unknown'] = False
+    processor = DataProcessor(config)
+
+    input_fields = {
+        'bucket': 'mock-bucket',
+        'key': 'mock-key',
+        'expected_size': 512
+    }
+    metadata = {
+        'file_path': '/tmp/mock-file',
+        'relative_key': 'relative/mock-key',
+        'cleanup': True
+    }
+    mock_dependencies['data_loader'].load_data.return_value = {
+        'data': [{'sample': 'data'}],
+        'metadata': metadata
+    }
+
+    with patch.object(DataProcessor, 'identify_product_log_type', return_value='NewType') as identify_mock, \
+            patch.object(DataProcessor, 'gather_data_fields') as gather_mock:
+        success = processor.process_data(input_fields)
+
+    assert success
+    identify_mock.assert_called_once()
+    gather_mock.assert_not_called()
+    mock_dependencies['transformer'].transform_content.assert_not_called()
+    mock_dependencies['sender_send_data'].assert_not_called()
+
+
+def test_process_data_processes_unknown_type_when_flag_enabled(mock_dependencies, config_fixture):
+    config = copy.deepcopy(config_fixture)
+    config['logs']['unknown'] = True
+    processor = DataProcessor(config)
+
+    input_fields = {
+        'bucket': 'mock-bucket',
+        'key': 'mock-key',
+        'expected_size': 512
+    }
+    metadata = {
+        'file_path': '/tmp/mock-file',
+        'relative_key': 'relative/mock-key',
+        'cleanup': True
+    }
+    mock_dependencies['data_loader'].load_data.return_value = {
+        'data': [{'sample': 'data'}],
+        'metadata': metadata
+    }
+
+    with patch.object(DataProcessor, 'identify_product_log_type', return_value='NewType') as identify_mock, \
+            patch.object(DataProcessor, 'gather_data_fields', return_value={'key': 'relative/mock-key'}) as gather_mock:
+        success = processor.process_data(input_fields)
+
+    assert success
+    identify_mock.assert_called_once()
+    gather_mock.assert_called_once()
+    mock_dependencies['transformer'].transform_content.assert_called_once()
+    mock_dependencies['sender_send_data'].assert_called_once()


### PR DESCRIPTION
## Summary
- expose an `unknown` log switch for Cloud WAAP agents in the feature metadata and sample configuration
- honor the new switch when normalizing agent configs and while verifying or processing log types
- add unit tests covering acceptance and rejection of unknown log types

## Testing
- PYTHONPATH=src pytest tests/logging_agent/test_data_proccesor.py

------
https://chatgpt.com/codex/tasks/task_b_69009a01987c8320bc0833c1f4d3f2b4