### PR TITLE
Normalize unknown Cloud WAAP logs when unify_fields is enabled

### DIFF
--- a/src/logging_agent/cloud_waap/cloudwaap_log_utils.py
+++ b/src/logging_agent/cloud_waap/cloudwaap_log_utils.py
@@ -8,6 +8,8 @@ from datetime import datetime
 # Create a logger for this module
 logger = get_logger('cloudwaap_log_utils')
 
+DEFAULT_PREFIX = "rdwrCld"
+
 class CloudWAAPProcessor:
     """
     CloudWAAPProcessor provides a collection of static methods designed to process
@@ -578,3 +580,114 @@ class CloudWAAPProcessor:
                 logger.error(f"Warning: Field '{old_key}' not found in event data")
 
         return event
+    @staticmethod
+    def _to_camel_case(key):
+        if not key:
+            return key
+        if not isinstance(key, str):
+            return key
+
+        if not re.search(r"[-_\s]", key):
+            return key
+
+        parts = [part for part in re.split(r"[^0-9A-Za-z]+", key) if part]
+        if not parts:
+            return key
+
+        first, *rest = parts
+        camel_key = first.lower() + ''.join(word.capitalize() for word in rest)
+        return camel_key
+
+    @staticmethod
+    def _to_prefixed_title_case(key, prefix):
+        if not key:
+            return key
+        if not isinstance(key, str):
+            return key
+
+        prefix = prefix or ""
+
+        if prefix and key.startswith(prefix):
+            remainder = key[len(prefix):]
+            if remainder and remainder[0].isupper():
+                return key
+
+        parts = [part for part in re.split(r"[^0-9A-Za-z]+", key) if part]
+        if not parts:
+            return prefix + key if prefix else key
+
+        title_key = ''.join(part.capitalize() for part in parts)
+        if not title_key and prefix:
+            return prefix
+        if not title_key:
+            return key
+
+        return f"{prefix}{title_key}" if prefix else title_key
+
+    @staticmethod
+    def _normalize_structure(value, style, prefix):
+        if isinstance(value, dict):
+            normalized = {}
+            for key, sub_value in value.items():
+                normalized_key = CloudWAAPProcessor._normalize_key(key, style, prefix)
+                normalized[normalized_key] = CloudWAAPProcessor._normalize_structure(sub_value, style, prefix)
+            return normalized
+        if isinstance(value, list):
+            return [CloudWAAPProcessor._normalize_structure(item, style, prefix) for item in value]
+        if isinstance(value, tuple):
+            return tuple(CloudWAAPProcessor._normalize_structure(item, style, prefix) for item in value)
+        return value
+
+    @staticmethod
+    def _normalize_key(key, style, prefix):
+        if not isinstance(key, str):
+            return key
+
+        key = key.strip()
+        if not key:
+            return key
+
+        if style == 'camel':
+            return CloudWAAPProcessor._to_camel_case(key)
+        if style == 'prefixed_title':
+            return CloudWAAPProcessor._to_prefixed_title_case(key, prefix)
+        return key
+
+    @staticmethod
+    def _resolve_prefix(field_mappings, product, log_type, output_format):
+        try:
+            product_mappings = field_mappings.get(product, {}) if isinstance(field_mappings, dict) else {}
+            prefix = product_mappings.get(log_type, {}).get(output_format, {}).get('prefix', '')
+            if prefix:
+                return prefix
+            for mapping in product_mappings.values():
+                candidate = mapping.get(output_format, {}).get('prefix')
+                if candidate:
+                    return candidate
+        except Exception as exc:
+            logger.debug(f"Unable to resolve prefix for {product}/{log_type}: {exc}")
+        return DEFAULT_PREFIX
+
+    @staticmethod
+    def normalize_event_fields(event, output_format, field_mappings, log_type, product, compatibility_mode=None):
+        try:
+            if not isinstance(event, dict):
+                return event
+
+            style = 'camel'
+            prefix = ''
+            if output_format in {'cef', 'leef'}:
+                style = 'prefixed_title'
+                prefix = CloudWAAPProcessor._resolve_prefix(field_mappings, product, log_type, output_format)
+
+            normalized_event = CloudWAAPProcessor._normalize_structure(event, style, prefix)
+
+            normalized_event.setdefault('logType', log_type or 'Unknown')
+            if product == 'cloud_waap' and output_format == 'json':
+                normalized_event.setdefault('product', 'Cloud WAAP')
+
+            return normalized_event
+        except Exception as exc:
+            logger.error(f"Error normalizing event fields for {product}/{log_type}: {exc}")
+            return event
+

--- a/src/logging_agent/transformer.py
+++ b/src/logging_agent/transformer.py
@@ -94,6 +94,17 @@ class Transformer:
             # Default to the original event if no specific processing is required
             self.logger.debug(f"No specific enrichment for log type: {log_type} in product: {self.product}")
             enriched_event = event
+            options = format_options or {}
+            unify_fields = options.get('unify_fields', True)
+            if unify_fields and self.product == 'cloud_waap':
+                enriched_event = CloudWAAPProcessor.normalize_event_fields(
+                    event,
+                    self.output_format,
+                    self.field_mappings,
+                    log_type or 'Unknown',
+                    self.product,
+                    self.compatibility_mode
+                )
 
         return enriched_event
 

--- a/tests/logging_agent/test_transformer_normalization.py
+++ b/tests/logging_agent/test_transformer_normalization.py
@@ -1,0 +1,83 @@
+import copy
+import json
+
+import pytest
+
+from logging_agent.field_mappings import FieldMappings
+from logging_agent.transformer import Transformer
+
+
+@pytest.fixture
+def transformer_config(config_fixture):
+    return copy.deepcopy(config_fixture)
+
+
+def test_enrich_event_normalizes_unknown_log_json(transformer_config):
+    transformer_config['output']['output_format'] = 'json'
+    transformer_config.setdefault('formats', {}).setdefault('json', {})
+    FieldMappings.load_field_mappings(['cloud_waap'], 'json', transformer_config['output'].get('compatibility_mode'))
+
+    transformer = Transformer(config=transformer_config)
+
+    event = {
+        'source_ip': '192.0.2.1',
+        'nested_field': {'inner_key': 'value'},
+        'list_field': [{'child_key': 1}, 'unchanged'],
+    }
+
+    enriched = transformer.enrich_event(event, 'UnknownType', {'unify_fields': True}, {})
+
+    assert 'sourceIp' in enriched and enriched['sourceIp'] == '192.0.2.1'
+    assert 'source_ip' not in enriched
+    assert enriched['nestedField']['innerKey'] == 'value'
+    assert isinstance(enriched['listField'][0], dict)
+    assert enriched['listField'][0]['childKey'] == 1
+    assert enriched['logType'] == 'UnknownType'
+    assert enriched['product'] == 'Cloud WAAP'
+
+
+def test_enrich_event_normalizes_unknown_log_cef(transformer_config):
+    transformer_config['output']['output_format'] = 'cef'
+    FieldMappings.load_field_mappings(['cloud_waap'], 'cef', transformer_config['output'].get('compatibility_mode'))
+
+    transformer = Transformer(config=transformer_config)
+
+    event = {
+        'attack_type': 'HTTP Flood',
+        'http-method': 'GET',
+    }
+
+    enriched = transformer.enrich_event(event, 'Unmapped', {'unify_fields': True}, {})
+
+    assert 'rdwrCldAttackType' in enriched and enriched['rdwrCldAttackType'] == 'HTTP Flood'
+    assert 'rdwrCldHttpMethod' in enriched and enriched['rdwrCldHttpMethod'] == 'GET'
+    assert enriched['logType'] == 'Unmapped'
+
+
+def test_transform_content_ecs_mode_preserves_normalized_keys(transformer_config):
+    transformer_config['output']['output_format'] = 'json'
+    transformer_config['output']['compatibility_mode'] = 'ecs'
+    transformer_config.setdefault('formats', {}).setdefault('json', {})
+    FieldMappings.load_field_mappings(['cloud_waap'], 'json', 'ecs')
+
+    transformer = Transformer(config=transformer_config)
+
+    event = {'source_ip': '203.0.113.10', 'user_agent': 'ExampleAgent/1.0'}
+
+    transformed = transformer.transform_content(
+        [event],
+        {'log_type': 'UnknownType', 'metadata': {}},
+        {'unify_fields': True}
+    )
+
+    assert isinstance(transformed, list)
+    ecs_payload = json.loads(transformed[0])
+    raw_log = ecs_payload['radware']['cloud_waap']
+    source_ip_value = raw_log['sourceIp']
+    if isinstance(source_ip_value, list):
+        assert '203.0.113.10' in source_ip_value
+    else:
+        assert source_ip_value == '203.0.113.10'
+    assert raw_log['userAgent'] == 'ExampleAgent/1.0'
+    assert raw_log['logType'] == 'UnknownType'
+


### PR DESCRIPTION
## Summary
- add a CloudWAAPProcessor helper that normalizes arbitrary event keys to camelCase or prefixed TitleCase depending on the output format
- apply the fallback normalizer in Transformer.enrich_event when unify_fields is enabled but no enrichment function exists
- add unit coverage to confirm unknown log types respect unify_fields for JSON, CEF, and ECS compatibility outputs

## Testing
- PYTHONPATH=src pytest tests/logging_agent/test_transformer_normalization.py

------
https://chatgpt.com/codex/tasks/task_b_69009efa87e88320b4b876523dca6f27