### PR TITLE
Fix S3 downloader tests to use temporary directory

### DIFF
--- a/tests/logging_agent/test_downloader.py
+++ b/tests/logging_agent/test_downloader.py
@@ -1,5 +1,7 @@
 
 # test_downloader.py
+import tempfile
+
 from logging_agent.downloader import S3Downloader
 
 def test_s3_downloader_download_success(mock_boto3_client):
@@ -12,12 +14,13 @@ def test_s3_downloader_download_success(mock_boto3_client):
 
     bucket = "test-bucket"
     key = "test-key"
-    download_path = "/fake/path/to/test-key"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        download_path = f"{tmpdir}/test-key"
 
-    result = downloader.download(bucket, key, download_path)
+        result = downloader.download(bucket, key, download_path)
 
-    assert result == True
-    mock_boto3_client.download_file.assert_called_once_with(bucket, key, download_path)
+        assert result is True
+        mock_boto3_client.download_file.assert_called_once_with(bucket, key, download_path)
 
 def test_s3_downloader_download_failure(mock_boto3_client):
     mock_boto3_client.download_file.side_effect = Exception("Failed to download")
@@ -31,10 +34,11 @@ def test_s3_downloader_download_failure(mock_boto3_client):
 
     bucket = "test-bucket"
     key = "test-key"
-    download_path = "/fake/path/to/test-key"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        download_path = f"{tmpdir}/test-key"
 
-    result = downloader.download(bucket, key, download_path)
+        result = downloader.download(bucket, key, download_path)
 
-    assert result == False
-    mock_boto3_client.download_file.assert_called_once_with(bucket, key, download_path)
+        assert result is False
+        mock_boto3_client.download_file.assert_called_once_with(bucket, key, download_path)
 


### PR DESCRIPTION
## Summary
- update S3 downloader tests to write downloads to a temporary directory
- ensure assertions use boolean identity checks

## Testing
- pytest tests/logging_agent/test_downloader.py

------
https://chatgpt.com/codex/tasks/task_b_6900cd3977a883208d2f7ae0c84509b0